### PR TITLE
Redirected from the old .org travis path to the new .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 propertyestimator
 ==============================
 [//]: # (Badges)
-[![Travis Build Status](https://travis-ci.com/openforcefield/propertyestimator.svg?branch=master)](https://travis-ci.org/openforcefield/propertyestimator)
+[![Travis Build Status](https://travis-ci.com/openforcefield/propertyestimator.svg?branch=master)](https://travis-ci.com/openforcefield/propertyestimator)
 [![codecov](https://codecov.io/gh/openforcefield/propertyestimator/branch/master/graph/badge.svg)](https://codecov.io/gh/openforcefield/propertyestimator/branch/master)
 
 Property calculation toolkit from the Open Forcefield Consortium.


### PR DESCRIPTION
## Description
Fixed a bad badge url which was merged as part of #2 and reverted in #3.