### PR TITLE
Fix docs builds on RTD

### DIFF
--- a/examples/property_estimator/single_machine.py
+++ b/examples/property_estimator/single_machine.py
@@ -5,7 +5,7 @@ import shutil
 from os import path
 
 from propertyestimator.datasets import ThermoMLDataSet
-from propertyestimator import client, runner
+from propertyestimator import client, server
 from propertyestimator.backends import PropertyEstimatorBackendResources, DaskLocalClusterBackend
 from propertyestimator.storage import LocalFileStorage
 from openforcefield.typing.engines import smirnoff
@@ -40,7 +40,7 @@ def run_property_estimator():
     calculation_backend = DaskLocalClusterBackend(1, 1, PropertyEstimatorBackendResources(2, 0))
     storage_backend = LocalFileStorage()
 
-    property_server = runner.PropertyCalculationRunner(calculation_backend,
+    property_server = server.PropertyCalculationRunner(calculation_backend,
                                                        storage_backend,
                                                        working_directory=working_directory)
 

--- a/examples/property_estimator/start_server.py
+++ b/examples/property_estimator/start_server.py
@@ -3,9 +3,9 @@
 import shutil
 from os import path
 
-from propertyestimator import runner
-from propertyestimator.estimator import DaskLocalClusterBackend
-from propertyestimator.estimator import LocalFileStorage
+from propertyestimator import server
+from propertyestimator.backends import DaskLocalClusterBackend
+from propertyestimator.storage import LocalFileStorage
 from propertyestimator.utils import setup_timestamp_logging
 
 
@@ -23,7 +23,7 @@ def start_property_estimator_server():
     calculation_backend = DaskLocalClusterBackend(1, 1)
     storage_backend = LocalFileStorage()
 
-    property_server = runner.PropertyCalculationRunner(calculation_backend,
+    property_server = server.PropertyCalculationRunner(calculation_backend,
                                                        storage_backend,
                                                        working_directory=working_directory)
 

--- a/propertyestimator/server.py
+++ b/propertyestimator/server.py
@@ -8,7 +8,6 @@ import uuid
 from os import path, makedirs
 from typing import List, Dict
 
-from openforcefield.typing.engines.smirnoff import ForceField
 from pydantic import BaseModel
 from simtk import unit
 from tornado.ioloop import IOLoop, PeriodicCallback
@@ -327,6 +326,8 @@ class PropertyCalculationRunner(TCPServer):
         PropertyRunnerDataModel
             The server side data model.
         """
+        from openforcefield.typing.engines.smirnoff.forcefield import ForceField
+
         parameter_set = ForceField([])
         parameter_set.__setstate__(client_data_model.parameter_set)
 

--- a/propertyestimator/workflow/protocols.py
+++ b/propertyestimator/workflow/protocols.py
@@ -12,7 +12,6 @@ from typing import Dict
 
 import mdtraj
 import numpy as np
-from openforcefield.typing.engines import smirnoff
 from simtk import openmm, unit
 from simtk.openmm import app, System, Platform
 
@@ -606,6 +605,8 @@ class BuildSmirnoffTopology(BaseProtocol):
                                                   message='{} could not be converted to a Molecule'.format(component))
 
             molecules.append(molecule)
+
+        from openforcefield.typing.engines import smirnoff
 
         system = parameter_set.createSystem(pdb_file.topology,
                                             molecules,


### PR DESCRIPTION
Moved any openforcefield imports from the global to the local scope to avoid having a docs dependance on openeye.