### PR TITLE
Simulation Data Storage Refactor

### DIFF
--- a/propertyestimator/client.py
+++ b/propertyestimator/client.py
@@ -181,7 +181,7 @@ class PropertyEstimatorResult(TypedBaseModel):
     estimated_properties: dict of str and PhysicalProperty
         A dictionary of the properties which were successfully estimated, where
         the dictionary key is the unique id of the property being estimated.
-    unsuccessful_properties: dict of str and PropertyEstimatorException
+    exceptions: list of PropertyEstimatorException
         A dictionary of the exceptions that were raised when unsuccessfully estimating a property.
         The dictionary key is the unique id of the property which could not be estimated.
     """
@@ -200,7 +200,7 @@ class PropertyEstimatorResult(TypedBaseModel):
         self.queued_properties = {}
 
         self.estimated_properties = {}
-        self.unsuccessful_properties = {}
+        self.exceptions = []
 
     def __getstate__(self):
 
@@ -210,7 +210,7 @@ class PropertyEstimatorResult(TypedBaseModel):
             'queued_properties': self.queued_properties,
 
             'estimated_properties': self.estimated_properties,
-            'unsuccessful_properties': self.unsuccessful_properties,
+            'exceptions': self.exceptions,
         }
 
     def __setstate__(self, state):
@@ -220,7 +220,7 @@ class PropertyEstimatorResult(TypedBaseModel):
         self.queued_properties = state['queued_properties']
 
         self.estimated_properties = state['estimated_properties']
-        self.unsuccessful_properties = state['unsuccessful_properties']
+        self.exceptions = state['exceptions']
 
 
 class ConnectionOptions(TypedBaseModel):

--- a/propertyestimator/client.py
+++ b/propertyestimator/client.py
@@ -181,9 +181,11 @@ class PropertyEstimatorResult(TypedBaseModel):
     estimated_properties: dict of str and PhysicalProperty
         A dictionary of the properties which were successfully estimated, where
         the dictionary key is the unique id of the property being estimated.
+    unsuccessful_properties: dict of str and PhysicalProperty
+        A dictionary of the properties which could not be estimated by the server.
     exceptions: list of PropertyEstimatorException
-        A dictionary of the exceptions that were raised when unsuccessfully estimating a property.
-        The dictionary key is the unique id of the property which could not be estimated.
+        A list of the exceptions that were raised when unsuccessfully carrying out this
+        estimation request.
     """
 
     def __init__(self, result_id=''):
@@ -200,6 +202,8 @@ class PropertyEstimatorResult(TypedBaseModel):
         self.queued_properties = {}
 
         self.estimated_properties = {}
+        self.unsuccessful_properties = {}
+
         self.exceptions = []
 
     def __getstate__(self):
@@ -210,6 +214,8 @@ class PropertyEstimatorResult(TypedBaseModel):
             'queued_properties': self.queued_properties,
 
             'estimated_properties': self.estimated_properties,
+            'unsuccessful_properties': self.unsuccessful_properties,
+
             'exceptions': self.exceptions,
         }
 
@@ -220,6 +226,8 @@ class PropertyEstimatorResult(TypedBaseModel):
         self.queued_properties = state['queued_properties']
 
         self.estimated_properties = state['estimated_properties']
+        self.unsuccessful_properties = state['unsuccessful_properties']
+
         self.exceptions = state['exceptions']
 
 

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -167,17 +167,17 @@ class PropertyCalculationLayer:
                                 continue
 
                             # Attach any extra metadata which is missing.
-                            with open(data_file, 'rw') as file:
+                            with open(data_file, 'r') as file:
 
                                 data_object = json.load(file, cls=TypedJSONDecoder)
 
                                 if data_object.force_field_id is None:
                                     data_object.force_field_id = server_request.force_field_id
 
+                            with open(data_file, 'w') as file:
                                 json.dump(data_object, file, cls=TypedJSONEncoder)
 
-                                substance_id = data_object.substance.identifier
-
+                            substance_id = data_object.substance.identifier
                             storage_backend.store_simulation_data(substance_id, data_directory)
 
                 matches = [x for x in server_request.queued_properties if x.id == returned_output.property_id]

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -131,6 +131,7 @@ class PropertyCalculationLayer:
         try:
 
             results = list(results_future.result())
+            results_future.release()
 
             for returned_output in results:
 

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -1,13 +1,13 @@
 """
 Defines the base API for defining new property estimator estimation layers.
 """
-
+import json
 import logging
-from typing import List
+import traceback
+from os import path
 
-from propertyestimator.properties import PhysicalProperty
-from propertyestimator.storage import StoredSimulationData
 from propertyestimator.utils.exceptions import PropertyEstimatorException
+from propertyestimator.utils.serialization import TypedJSONDecoder, TypedJSONEncoder
 
 available_layers = {}
 
@@ -42,17 +42,17 @@ class CalculationLayerResult:
         self.property_id = None
 
         self.calculated_property = None
-        self.workflow_error = None
+        self.exception = None
 
-        self.data_to_store = []
+        self.data_directories_to_store = []
 
     def __getstate__(self):
 
         return {
             'property_id': self.property_id,
             'calculated_property': self.calculated_property,
-            'workflow_error': self.workflow_error,
-            'data_to_store': self.data_to_store
+            'exception': self.exception,
+            'data_directories_to_store': self.data_directories_to_store
         }
 
     def __setstate__(self, state):
@@ -60,9 +60,9 @@ class CalculationLayerResult:
         self.property_id = state['property_id']
 
         self.calculated_property = state['calculated_property']
-        self.workflow_error = state['workflow_error']
+        self.exception = state['exception']
 
-        self.data_to_store = state['data_to_store']
+        self.data_directories_to_store = state['data_directories_to_store']
 
 
 class PropertyCalculationLayer:
@@ -75,7 +75,7 @@ class PropertyCalculationLayer:
     """
 
     @staticmethod
-    def _await_results(calculation_backend, storage_backend, layer_directory, data_model,
+    def _await_results(calculation_backend, storage_backend, layer_directory, server_request,
                        callback, submitted_futures, synchronous=False):
         """A helper method to handle passing the results of this layer back to
         the main thread.
@@ -88,8 +88,8 @@ class PropertyCalculationLayer:
             The backend used to store / retrieve data from previous calculations.
         layer_directory: str
             The local directory in which to store all local, temporary calculation data from this layer.
-        data_model: PropertyEstimatorServer.ServerEstimationRequest
-            The data model encoding the awaited calculation.
+        server_request: PropertyEstimatorServer.ServerEstimationRequest
+            The request object which spawned the awaited results.
         callback: function
             The function to call when the backend returns the results (or an error).
         submitted_futures: list(dask.distributed.Future)
@@ -98,12 +98,39 @@ class PropertyCalculationLayer:
             If true, this function will block until the calculation has completed.
         """
 
-        callback_future = calculation_backend.submit_task(return_args, data_model, *submitted_futures)
+        callback_future = calculation_backend.submit_task(return_args, *submitted_futures)
 
-        def callback_wrapper(future_object):
+        def callback_wrapper(results_future):
+            PropertyCalculationLayer._process_results(results_future, server_request, storage_backend, callback)
 
-            results = list(future_object.result())
-            returned_data_model = results.pop(0)
+        if synchronous:
+            callback_wrapper(callback_future)
+        else:
+            callback_future.add_done_callback(callback_wrapper)
+
+    @staticmethod
+    def _process_results(results_future, server_request, storage_backend, callback):
+        """Processes the results of a calculation layer, updates the server request,
+        then passes it back to the callback ready for propagation to the next layer
+        in the stack.
+
+        Parameters
+        ----------
+        results_future: distributed.Future
+            The future object which will hold the results.
+        server_request: PropertyEstimatorServer.ServerEstimationRequest
+            The request object which spawned the awaited results.
+        storage_backend: PropertyEstimatorStorage
+            The backend used to store / retrieve data from previous calculations.
+        callback: function
+            The function to call when the backend returns the results (or an error).
+        """
+
+        # Wrap everything in a try catch to make sure the whole calculation backend /
+        # server doesn't go down when an unexpected exception occurs.
+        try:
+
+            results = list(results_future.result())
 
             for returned_output in results:
 
@@ -112,46 +139,71 @@ class PropertyCalculationLayer:
                     # particular property.
                     continue
 
-                return_object = None
+                if not isinstance(returned_output, CalculationLayerResult):
 
-                if returned_output.workflow_error is not None:
-                    return_object = returned_output.workflow_error
+                    # Make sure we are actually dealing with the object we expect.
+                    raise ValueError('The output of the calculation was not '
+                                     'a CalculationLayerResult as expected.')
+
+                if returned_output.exception is not None:
+                    # If an exception was raised, make sure to add it to the list.
+                    server_request.exceptions.append(returned_output.exception)
+
                 else:
-                    return_object = returned_output.calculated_property
 
-                # Make sure to store any important calculation data.
-                if returned_output.data_to_store is not None and returned_output.calculated_property is not None:
+                    # Make sure to store any important calculation data if no exceptions
+                    # were thrown.
+                    if (returned_output.data_directories_to_store is not None and
+                        returned_output.calculated_property is not None):
 
-                    for data in returned_output.data_to_store:
+                        for data_directory in returned_output.data_directories_to_store:
 
-                        if data.force_field_id is None:
-                            data.force_field_id = data_model.force_field_id
+                            data_file = path.join(data_directory, 'data.json')
 
-                        substance_id = data.substance.identifier
+                            # Make sure the data directory / file to store actually exists
+                            if not path.isdir(data_directory) or not path.isfile(data_file):
+                                logging.info(f'Invalid data directory ({data_directory}) / file ({data_file})')
+                                continue
 
-                        storage_backend.store_simulation_data(substance_id, data)
+                            # Attach any extra metadata which is missing.
+                            with open(data_file, 'rw') as file:
 
-                matches = [x for x in returned_data_model.queued_properties if x.id == returned_output.property_id]
+                                data_object = json.load(file, cls=TypedJSONDecoder)
+
+                                if data_object.force_field_id is None:
+                                    data_object.force_field_id = server_request.force_field_id
+
+                                json.dump(data_object, file, cls=TypedJSONEncoder)
+
+                                substance_id = data_object.substance.identifier
+
+                            storage_backend.store_simulation_data(substance_id, data_directory)
+
+                matches = [x for x in server_request.queued_properties if x.id == returned_output.property_id]
 
                 if len(matches) != 1:
-                    logging.info('An id conflict occurred... unexpected results may ensue.')
+                    raise ValueError(f'A property id ({returned_output.property_id}) conflict occurred.')
 
                 for match in matches:
-                    returned_data_model.queued_properties.remove(match)
+                    server_request.queued_properties.remove(match)
 
-                from propertyestimator.properties import PhysicalProperty
+                if returned_output.exception is None:
 
-                if isinstance(return_object, PhysicalProperty):
-                    returned_data_model.estimated_properties[return_object.id] = return_object
-                else:
-                    returned_data_model.unsuccessful_properties[returned_output.property_id] = return_object
+                    server_request.estimated_properties[returned_output.property_id] = \
+                        returned_output.calculated_property
 
-            callback(returned_data_model)
+        except Exception as e:
 
-        if synchronous:
-            callback_wrapper(callback_future)
-        else:
-            callback_future.add_done_callback(callback_wrapper)
+            logging.info(f'Error processing layer results for request {server_request.id}')
+
+            formatted_exception = traceback.format_exception(None, e, e.__traceback__)
+
+            exception = PropertyEstimatorException(message='An unhandled internal exception '
+                                                           'occurred: {}'.format(formatted_exception))
+
+            server_request.exceptions.append(exception)
+
+        callback(server_request)
 
     @staticmethod
     def schedule_calculation(calculation_backend, storage_backend, layer_directory,

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -39,12 +39,12 @@ class CalculationLayerResult:
     def __init__(self):
         """Constructs a new CalculationLayerResult object.
         """
-        self.property_id: str = None
+        self.property_id = None
 
-        self.calculated_property: PhysicalProperty = None
-        self.workflow_error: PropertyEstimatorException = None
+        self.calculated_property = None
+        self.workflow_error = None
 
-        self.data_to_store: List[StoredSimulationData] = None
+        self.data_to_store = []
 
     def __getstate__(self):
 

--- a/propertyestimator/layers/reweighting.py
+++ b/propertyestimator/layers/reweighting.py
@@ -2,13 +2,14 @@
 The simulation reweighting estimation layer.
 """
 import abc
+import json
 import logging
 import pickle
 from os import path
 
 from propertyestimator.layers import register_calculation_layer, PropertyCalculationLayer
 from propertyestimator.substances import Mixture
-from propertyestimator.utils.serialization import serialize_force_field
+from propertyestimator.utils.serialization import serialize_force_field, TypedJSONDecoder
 from propertyestimator.utils.utils import SubhookedABCMeta
 from propertyestimator.workflow import WorkflowGraph, Workflow
 from propertyestimator.workflow.workflow import IWorkflowProperty
@@ -87,30 +88,31 @@ class ReweightingLayer(PropertyCalculationLayer):
                 # interface can be reweighted
                 continue
 
-            existing_data = storage_backend.retrieve_simulation_data(physical_property.substance,
-                                                                     physical_property.multi_component_property)
+            existing_data_paths = storage_backend.retrieve_simulation_data(physical_property.substance,
+                                                                           physical_property.multi_component_property)
 
-            if len(existing_data) == 0:
+            if len(existing_data_paths) == 0:
                 continue
 
             # Take data from the storage backend and save it in the working directory.
-            for substance_id in existing_data:
+            for substance_id in existing_data_paths:
 
                 if substance_id not in data_paths:
                     data_paths[substance_id] = []
 
-                for data in existing_data[substance_id]:
+                for data_directory in existing_data_paths[substance_id]:
 
-                    data_path = path.join(layer_directory, data.unique_id)
+                    data = None
+
+                    with open(path.join(data_directory, 'data.json'), 'r') as file:
+                        data = json.load(file, cls=TypedJSONDecoder)
+
                     force_field_path = path.join(layer_directory, data.force_field_id)
 
-                    path_tuple = (data_path, force_field_path)
+                    path_tuple = (data_directory, force_field_path)
 
                     if path_tuple in data_paths[substance_id]:
                         continue
-
-                    with open(data_path, 'wb') as file:
-                        pickle.dump(data, file)
 
                     if not path.isfile(force_field_path):
 

--- a/propertyestimator/properties/density.py
+++ b/propertyestimator/properties/density.py
@@ -27,7 +27,7 @@ class Density(PhysicalProperty):
         return False
 
     @staticmethod
-    def get_default_workflow_schema(calculation_layer, options):
+    def get_default_workflow_schema(calculation_layer, options=None):
 
         if calculation_layer == 'SimulationLayer':
             return Density.get_default_simulation_workflow_schema(options)
@@ -37,7 +37,7 @@ class Density(PhysicalProperty):
         return None
 
     @staticmethod
-    def get_default_simulation_workflow_schema(options):
+    def get_default_simulation_workflow_schema(options=None):
         """Returns the default workflow to use when estimating this property
         from direct simulations.
 

--- a/propertyestimator/properties/dielectric.py
+++ b/propertyestimator/properties/dielectric.py
@@ -313,7 +313,7 @@ class DielectricConstant(PhysicalProperty):
         return False
 
     @staticmethod
-    def get_default_workflow_schema(calculation_layer, options):
+    def get_default_workflow_schema(calculation_layer, options=None):
 
         if calculation_layer == 'SimulationLayer':
             return DielectricConstant.get_default_simulation_workflow_schema(options)
@@ -323,7 +323,7 @@ class DielectricConstant(PhysicalProperty):
         return None
 
     @staticmethod
-    def get_default_simulation_workflow_schema(options):
+    def get_default_simulation_workflow_schema(options=None):
         """Returns the default workflow to use when estimating this property
         from direct simulations.
 
@@ -479,7 +479,7 @@ class DielectricConstant(PhysicalProperty):
         return schema
 
     @staticmethod
-    def get_default_reweighting_workflow_schema(options):
+    def get_default_reweighting_workflow_schema(options=None):
         """Returns the default workflow to use when estimating this property
         by reweighting existing data.
 

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -229,7 +229,7 @@ class EnthalpyOfMixing(PhysicalProperty):
                                                  extract_uncorrelated_statistics)
 
     @staticmethod
-    def get_default_workflow_schema(calculation_layer, options):
+    def get_default_workflow_schema(calculation_layer, options=None):
 
         if calculation_layer == 'SimulationLayer':
             return EnthalpyOfMixing.get_default_simulation_workflow_schema(options)
@@ -239,7 +239,7 @@ class EnthalpyOfMixing(PhysicalProperty):
         return None
 
     @staticmethod
-    def get_default_simulation_workflow_schema(options):
+    def get_default_simulation_workflow_schema(options=None):
         """Returns the default workflow to use when estimating this property
         from direct simulations.
 
@@ -367,7 +367,7 @@ class EnthalpyOfMixing(PhysicalProperty):
         return schema
 
     @staticmethod
-    def get_default_reweighting_workflow_schema(options):
+    def get_default_reweighting_workflow_schema(options=None):
         """Returns the default workflow to use when estimating this property
         by reweighting existing data.
 

--- a/propertyestimator/properties/properties.py
+++ b/propertyestimator/properties/properties.py
@@ -300,7 +300,7 @@ class PhysicalProperty(TypedBaseModel):
         self.uncertainty = uncertainty
 
     @staticmethod
-    def get_default_workflow_schema(calculation_layer, options):
+    def get_default_workflow_schema(calculation_layer, options=None):
         """Returns the default workflow schema to use for
         a specific calculation layer.
 

--- a/propertyestimator/server.py
+++ b/propertyestimator/server.py
@@ -81,7 +81,7 @@ class PropertyEstimatorServer(TCPServer):
             self.queued_properties = queued_properties or []
 
             self.estimated_properties = {}
-            self.unsuccessful_properties = {}
+            self.exceptions = []
 
             self.options = options
 
@@ -94,7 +94,7 @@ class PropertyEstimatorServer(TCPServer):
                 'queued_properties': self.queued_properties,
 
                 'estimated_properties': self.estimated_properties,
-                'unsuccessful_properties': self.unsuccessful_properties,
+                'exceptions': self.exceptions,
 
                 'options': self.options,
 
@@ -107,7 +107,7 @@ class PropertyEstimatorServer(TCPServer):
             self.queued_properties = state['queued_properties']
 
             self.estimated_properties = state['estimated_properties']
-            self.unsuccessful_properties = state['unsuccessful_properties']
+            self.exceptions = state['exceptions']
 
             self.options = state['options']
 
@@ -469,10 +469,7 @@ class PropertyEstimatorServer(TCPServer):
             for substance_id in server_request.estimated_properties:
                 request_results.estimated_properties[substance_id] = server_request.estimated_properties[substance_id]
 
-            for substance_id in server_request.unsuccessful_properties:
-
-                request_results.unsuccessful_properties[substance_id] = \
-                    server_request.unsuccessful_properties[substance_id]
+            request_results.exceptions.extend(server_request.exceptions)
 
         return request_results
 
@@ -507,7 +504,7 @@ class PropertyEstimatorServer(TCPServer):
                                                               f'supported by the server.')
 
             for queued_calculation in server_request.queued_properties:
-                server_request.unsuccessful_properties[queued_calculation.id] = error_object
+                server_request.exceptions.append(error_object)
 
             server_request.options.allowed_calculation_layers.append(current_layer_type)
             server_request.queued_properties = []

--- a/propertyestimator/server.py
+++ b/propertyestimator/server.py
@@ -194,7 +194,7 @@ class PropertyEstimatorServer(TCPServer):
 
         self._server_request_ids_per_client_id[client_request_id] = []
 
-        # Pass the ids of the submitted calculations back to the
+        # Pass the ids of the submitted requests back to the
         # client.
         encoded_job_ids = json.dumps(client_request_id).encode()
         length = pack_int(len(encoded_job_ids))
@@ -303,7 +303,8 @@ class PropertyEstimatorServer(TCPServer):
 
     def _find_server_estimation_request(self, request):
         """Checks whether the server is currently, or has previously completed
-        a request to estimate a set of properties for a particular substance.
+        a request to estimate a set of properties for a particular substance
+        using the same force field parameters and estimation options.
 
         Parameters
         ----------
@@ -372,6 +373,8 @@ class PropertyEstimatorServer(TCPServer):
 
         server_requests = {}
 
+        # Split the full list of properties into lists partitioned by
+        # substance.
         properties_by_substance = {}
 
         for physical_property in client_data_model.properties:

--- a/propertyestimator/server.py
+++ b/propertyestimator/server.py
@@ -81,6 +81,8 @@ class PropertyEstimatorServer(TCPServer):
             self.queued_properties = queued_properties or []
 
             self.estimated_properties = {}
+            self.unsuccessful_properties = {}
+
             self.exceptions = []
 
             self.options = options
@@ -94,6 +96,8 @@ class PropertyEstimatorServer(TCPServer):
                 'queued_properties': self.queued_properties,
 
                 'estimated_properties': self.estimated_properties,
+                'unsuccessful_properties': self.unsuccessful_properties,
+
                 'exceptions': self.exceptions,
 
                 'options': self.options,
@@ -107,6 +111,8 @@ class PropertyEstimatorServer(TCPServer):
             self.queued_properties = state['queued_properties']
 
             self.estimated_properties = state['estimated_properties']
+            self.unsuccessful_properties = state['unsuccessful_properties']
+
             self.exceptions = state['exceptions']
 
             self.options = state['options']
@@ -464,10 +470,31 @@ class PropertyEstimatorServer(TCPServer):
                                                           f'request was not found on the server.')
 
             for physical_property in server_request.queued_properties:
-                request_results.queued_properties[physical_property.substance.identifier] = physical_property
+
+                substance_id = physical_property.substance.identifier
+
+                if substance_id not in request_results.queued_properties:
+                    request_results.queued_properties[substance_id] = []
+
+                request_results.queued_properties[substance_id].append(physical_property)
+
+            for substance_id in server_request.unsuccessful_properties:
+
+                physical_property = server_request.unsuccessful_properties[substance_id]
+
+                if substance_id not in request_results.unsuccessful_properties:
+                    request_results.unsuccessful_properties[substance_id] = []
+
+                request_results.unsuccessful_properties[substance_id].append(physical_property)
 
             for substance_id in server_request.estimated_properties:
-                request_results.estimated_properties[substance_id] = server_request.estimated_properties[substance_id]
+
+                physical_property = server_request.estimated_properties[substance_id]
+
+                if substance_id not in request_results.estimated_properties:
+                    request_results.estimated_properties[substance_id] = []
+
+                request_results.estimated_properties[substance_id].append(physical_property)
 
             request_results.exceptions.extend(server_request.exceptions)
 
@@ -489,6 +516,18 @@ class PropertyEstimatorServer(TCPServer):
         if len(server_request.options.allowed_calculation_layers) == 0 or \
            len(server_request.queued_properties) == 0:
 
+            # Move any remaining properties to the unsuccessful list.
+            for physical_property in server_request.queued_properties:
+
+                substance_id = physical_property.substance.identifier
+
+                if substance_id not in server_request.unsuccessful_properties:
+                    server_request.unsuccessful_properties[substance_id] = []
+
+                server_request.unsuccessful_properties[substance_id].append(physical_property)
+
+                server_request.queued_properties = []
+
             self._queued_calculations.pop(server_request.id)
             self._finished_calculations[server_request.id] = server_request
 
@@ -501,10 +540,9 @@ class PropertyEstimatorServer(TCPServer):
 
             # Kill all remaining properties if we reach an unsupported calculation layer.
             error_object = PropertyEstimatorException(message=f'The {current_layer_type} layer is not '
-                                                              f'supported by the server.')
+                                                              f'supported by / available on the server.')
 
-            for queued_calculation in server_request.queued_properties:
-                server_request.exceptions.append(error_object)
+            server_request.exceptions.append(error_object)
 
             server_request.options.allowed_calculation_layers.append(current_layer_type)
             server_request.queued_properties = []

--- a/propertyestimator/storage/dataclasses.py
+++ b/propertyestimator/storage/dataclasses.py
@@ -4,11 +4,12 @@ A collection of classes representing data stored by a storage backend.
 
 
 class StoredSimulationData:
-    """A container class for storing data from a previous simulation.
+    """A class which describes a collection of data which has been cached
+    from a previous simulation.
     """
 
     def __init__(self):
-
+        """Constructs a new StoredSimulationData object"""
         self.unique_id = None
 
         self.substance = None
@@ -17,9 +18,10 @@ class StoredSimulationData:
         self.source_calculation_id = None
         self.provenance = None
 
-        self.statistical_inefficiency = 0.0
+        self.coordinate_path = None
+        self.trajectory_path = None
 
-        self.trajectory_data = None
-        self.statistics_data = None
+        self.statistics_path = None
+        self.statistical_inefficiency = 0.0
 
         self.force_field_id = None

--- a/propertyestimator/storage/dataclasses.py
+++ b/propertyestimator/storage/dataclasses.py
@@ -18,10 +18,48 @@ class StoredSimulationData:
         self.source_calculation_id = None
         self.provenance = None
 
-        self.coordinate_path = None
-        self.trajectory_path = None
+        self.coordinate_file_name = None
+        self.trajectory_file_name = None
 
-        self.statistics_path = None
+        self.statistics_file_name = None
         self.statistical_inefficiency = 0.0
 
         self.force_field_id = None
+
+    def __getstate__(self):
+
+        return {
+            'unique_id': self.unique_id,
+
+            'substance': self.substance,
+            'thermodynamic_state': self.thermodynamic_state,
+
+            'source_calculation_id': self.source_calculation_id,
+            'provenance': self.provenance,
+
+            'coordinate_file_name': self.coordinate_file_name,
+            'trajectory_file_name': self.trajectory_file_name,
+
+            'statistics_file_name': self.statistics_file_name,
+            'statistical_inefficiency': self.statistical_inefficiency,
+
+            'force_field_id': self.force_field_id,
+        }
+
+    def __setstate__(self, state):
+
+        self.unique_id = state['unique_id']
+
+        self.substance = state['substance']
+        self.thermodynamic_state = state['thermodynamic_state']
+
+        self.source_calculation_id = state['source_calculation_id']
+        self.provenance = state['provenance']
+
+        self.coordinate_file_name = state['coordinate_file_name']
+        self.trajectory_file_name = state['trajectory_file_name']
+
+        self.statistics_file_name = state['statistics_file_name']
+        self.statistical_inefficiency = state['statistical_inefficiency']
+
+        self.force_field_id = state['force_field_id']

--- a/propertyestimator/storage/localfile.py
+++ b/propertyestimator/storage/localfile.py
@@ -5,7 +5,9 @@ A local file based storage backend.
 import logging
 import pickle
 from os import path, makedirs
+from shutil import move
 
+from propertyestimator.substances import Mixture
 from .storage import PropertyEstimatorStorage
 
 
@@ -69,3 +71,41 @@ class LocalFileStorage(PropertyEstimatorStorage):
             return False
 
         return True
+
+    def store_simulation_data(self, substance_id, simulation_data_directory):
+
+        unique_id = super(LocalFileStorage, self).store_simulation_data(substance_id,
+                                                                        simulation_data_directory)
+
+        move(simulation_data_directory, path.join(self._root_directory, f'{unique_id}_data'))
+        return unique_id
+
+    def retrieve_simulation_data(self, substance, include_pure_data=True):
+
+        substance_ids = [substance.identifier]
+
+        if isinstance(substance, Mixture) and include_pure_data is True:
+
+            for component in substance.components:
+
+                component_mixture = Mixture()
+                component_mixture.add_component(component.smiles, 1.0, False)
+
+                if component_mixture.identifier not in substance_ids:
+                    substance_ids.append(component_mixture.identifier)
+
+        return_paths = {}
+
+        for substance_id in substance_ids:
+
+            if substance_id not in self._simulation_data_by_substance:
+                continue
+
+            return_paths[substance_id] = []
+
+            for simulation_data_key in self._simulation_data_by_substance[substance_id]:
+
+                stored_object = self.retrieve_object(simulation_data_key)
+                return_paths[substance_id].append(path.join(self._root_directory, f'{stored_object.unique_id}_data'))
+
+        return return_paths

--- a/propertyestimator/tests/test_storage.py
+++ b/propertyestimator/tests/test_storage.py
@@ -3,6 +3,8 @@ Units tests for propertyestimator.storage
 """
 import json
 import tempfile
+from os import path, makedirs
+from shutil import rmtree
 
 from simtk import unit
 
@@ -10,7 +12,7 @@ from propertyestimator.storage import LocalFileStorage, StoredSimulationData
 from propertyestimator.substances import Mixture
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils import get_data_filename
-from propertyestimator.utils.serialization import serialize_force_field
+from propertyestimator.utils.serialization import serialize_force_field, TypedJSONEncoder, TypedJSONDecoder
 
 
 def test_local_force_field_storage():
@@ -53,20 +55,43 @@ def test_local_simulation_storage():
 
     dummy_simulation_data.substance = substance
 
-    with tempfile.TemporaryDirectory() as temporary_directory:
+    temporary_data_directory = 'temp_data'
+    temporary_backend_directory = 'storage_dir'
 
-        local_storage = LocalFileStorage(temporary_directory)
-        local_storage.store_simulation_data(substance.identifier, dummy_simulation_data)
+    if path.isdir(temporary_data_directory):
+        rmtree(temporary_data_directory)
 
-        retrieved_data_array = local_storage.retrieve_simulation_data(substance)
-        assert len(retrieved_data_array) == 1
+    if path.isdir(temporary_backend_directory):
+        rmtree(temporary_backend_directory)
 
-        retrieved_data = retrieved_data_array[substance.identifier][0]
+    makedirs(temporary_data_directory)
+    makedirs(temporary_backend_directory)
 
-        assert dummy_simulation_data.thermodynamic_state == retrieved_data.thermodynamic_state
-        assert dummy_simulation_data.statistical_inefficiency == retrieved_data.statistical_inefficiency
-        assert dummy_simulation_data.force_field_id == retrieved_data.force_field_id
-        assert dummy_simulation_data.substance == retrieved_data.substance
+    with open(path.join(temporary_data_directory, 'data.json'), 'w') as file:
+        json.dump(dummy_simulation_data, file, cls=TypedJSONEncoder)
 
-        local_storage_new = LocalFileStorage(temporary_directory)
-        assert local_storage_new.has_object(dummy_simulation_data.unique_id)
+    local_storage = LocalFileStorage(temporary_backend_directory)
+    dummy_simulation_data.unique_id = local_storage.store_simulation_data(substance.identifier,
+                                                                          temporary_data_directory)
+
+    retrieved_data_directories = local_storage.retrieve_simulation_data(substance)
+    assert len(retrieved_data_directories) == 1
+
+    retrieved_data_directory = retrieved_data_directories[substance.identifier][0]
+
+    with open(path.join(retrieved_data_directory, 'data.json'), 'r') as file:
+        retrieved_data = json.load(file, cls=TypedJSONDecoder)
+
+    assert dummy_simulation_data.thermodynamic_state == retrieved_data.thermodynamic_state
+    assert dummy_simulation_data.statistical_inefficiency == retrieved_data.statistical_inefficiency
+    assert dummy_simulation_data.force_field_id == retrieved_data.force_field_id
+    assert dummy_simulation_data.substance == retrieved_data.substance
+
+    local_storage_new = LocalFileStorage(temporary_backend_directory)
+    assert local_storage_new.has_object(dummy_simulation_data.unique_id)
+
+    if path.isdir(temporary_data_directory):
+        rmtree(temporary_data_directory)
+
+    if path.isdir(temporary_backend_directory):
+        rmtree(temporary_backend_directory)

--- a/propertyestimator/workflow/schemas.py
+++ b/propertyestimator/workflow/schemas.py
@@ -135,8 +135,13 @@ class ProtocolReplicator(TypedBaseModel):
 
 
 class WorkflowOutputToStore:
+    """An object which describes which data should be cached
+    after a workflow has finished executing, and from which
+    completed protocols should the data be collected from.
+    """
 
     def __init__(self):
+        """Constructs a new WorkflowOutputToStore object."""
 
         self.substance = None
 

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -1189,7 +1189,7 @@ class WorkflowGraph:
             # and uncertainty.
             if isinstance(protocol_results, PropertyEstimatorException):
 
-                return_object.workflow_error = protocol_results
+                return_object.exception = protocol_results
                 return return_object
 
             for output_path, output_value in protocol_results.items():
@@ -1213,7 +1213,7 @@ class WorkflowGraph:
         property_to_return.uncertainty = results_by_id[value_reference].uncertainty
 
         return_object.calculated_property = property_to_return
-        return_object.data_to_store = []
+        return_object.data_directories_to_store = []
 
         # TODO: At the moment it is assumed that the output of a WorkflowGraph is
         #       a set of StoredSimulationData. This should be abstracted and made
@@ -1227,7 +1227,7 @@ class WorkflowGraph:
                                                  property_to_return,
                                                  results_by_id)
 
-            return_object.data_to_store.append(results_directory)
+            return_object.data_directories_to_store.append(results_directory)
 
         return return_object
 

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -1026,82 +1026,105 @@ class WorkflowGraph:
         # The path where the output of this protocol will be stored.
         output_dictionary_path = path.join(directory, '{}_output.json'.format(protocol_schema.id))
 
-        # If the output file already exists, we can assume this protocol has already
-        # been executed and we can return immediately without re-executing.
-        if path.isfile(output_dictionary_path):
-            return protocol_schema.id, output_dictionary_path
+        # We need to make sure ALL exceptions are handled within this method,
+        # or any function which will be executed on a calculation backend to
+        # avoid accidentally killing the backend.
+        try:
 
-        # Store the results of the relevant previous protocols in a handy dictionary.
-        # If one of the results is a failure, propagate it up the chain.
-        previous_outputs_by_path = {}
+            # If the output file already exists, we can assume this protocol has already
+            # been executed and we can return immediately without re-executing.
+            if path.isfile(output_dictionary_path):
+                return protocol_schema.id, output_dictionary_path
 
-        for parent_id, previous_output_path in previous_output_paths:
+            # Store the results of the relevant previous protocols in a handy dictionary.
+            # If one of the results is a failure, propagate it up the chain.
+            previous_outputs_by_path = {}
 
-            parent_output = None
+            for parent_id, previous_output_path in previous_output_paths:
+
+                parent_output = None
+
+                try:
+
+                    with open(previous_output_path, 'r') as file:
+                        parent_output = json.load(file, cls=TypedJSONDecoder)
+
+                except json.JSONDecodeError as e:
+
+                    formatted_exception = traceback.format_exception(None, e, e.__traceback__)
+
+                    exception = PropertyEstimatorException(directory,
+                                                           f'Could not load the output dictionary of {parent_id} '
+                                                           f'({previous_output_path}): {formatted_exception}')
+
+                    WorkflowGraph._save_protocol_output(output_dictionary_path,
+                                                        exception)
+
+                    return protocol_schema.id, output_dictionary_path
+
+                if isinstance(parent_output, PropertyEstimatorException):
+                    return protocol_schema.id, previous_output_path
+
+                for output_path, output_value in parent_output.items():
+
+                    property_name, protocol_ids = ProtocolPath.to_components(output_path)
+
+                    if len(protocol_ids) == 0 or (len(protocol_ids) > 0 and protocol_ids[0] != parent_id):
+                        protocol_ids.insert(0, parent_id)
+
+                    final_path = ProtocolPath(property_name, *protocol_ids)
+                    previous_outputs_by_path[final_path] = output_value
+
+            # Recreate the protocol on the backend to bypass the need for static methods
+            # and awkward args and kwargs syntax.
+            protocol = available_protocols[protocol_schema.type](protocol_schema.id)
+            protocol.schema = protocol_schema
+
+            if not path.isdir(directory):
+                makedirs(directory)
+
+            # Pass the outputs of previously executed protocols as input to the
+            # protocol to execute.
+            for input_path in protocol.required_inputs:
+
+                value_references = protocol.get_value_references(input_path)
+
+                for source_path, target_path in value_references.items():
+
+                    if (target_path.start_protocol == input_path.start_protocol or
+                        target_path.start_protocol == protocol.id):
+
+                        continue
+
+                    protocol.set_value(source_path, previous_outputs_by_path[target_path])
+
+            logging.info('Executing protocol: {}'.format(protocol.id))
+
+            start_time = time.perf_counter()
+            output_dictionary = protocol.execute(directory, available_resources)
+            end_time = time.perf_counter()
+
+            logging.info('Protocol finished executing ({} ms): {}'.format((end_time-start_time)*1000, protocol.id))
 
             try:
 
-                with open(previous_output_path, 'r') as file:
-                    parent_output = json.load(file, cls=TypedJSONDecoder)
+                WorkflowGraph._save_protocol_output(output_dictionary_path, output_dictionary)
 
-            except json.JSONDecodeError as e:
+            except TypeError as e:
 
                 formatted_exception = traceback.format_exception(None, e, e.__traceback__)
 
-                exception = PropertyEstimatorException(directory,
-                                                       f'Could not load the output dictionary of {parent_id} '
-                                                       f'({previous_output_path}): {formatted_exception}')
+                exception = PropertyEstimatorException(directory=directory,
+                                                       message='Could not save the output dictionary of {} ({}): {}'.format(
+                                                               protocol.id, output_dictionary_path, formatted_exception))
 
-                WorkflowGraph._save_protocol_output(output_dictionary_path,
-                                                    exception)
+                WorkflowGraph._save_protocol_output(output_dictionary_path, exception)
 
-                return protocol_schema.id, output_dictionary_path
+            return protocol.id, output_dictionary_path
 
-            if isinstance(parent_output, PropertyEstimatorException):
-                return protocol_schema.id, previous_output_path
-
-            for output_path, output_value in parent_output.items():
-
-                property_name, protocol_ids = ProtocolPath.to_components(output_path)
-
-                if len(protocol_ids) == 0 or (len(protocol_ids) > 0 and protocol_ids[0] != parent_id):
-                    protocol_ids.insert(0, parent_id)
-
-                final_path = ProtocolPath(property_name, *protocol_ids)
-                previous_outputs_by_path[final_path] = output_value
-
-        # Recreate the protocol on the backend to bypass the need for static methods
-        # and awkward args and kwargs syntax.
-        protocol = available_protocols[protocol_schema.type](protocol_schema.id)
-        protocol.schema = protocol_schema
-
-        if not path.isdir(directory):
-            makedirs(directory)
-
-        # Pass the outputs of previously executed protocols as input to the
-        # protocol to execute.
-        for input_path in protocol.required_inputs:
-
-            value_references = protocol.get_value_references(input_path)
-
-            for source_path, target_path in value_references.items():
-
-                if (target_path.start_protocol == input_path.start_protocol or
-                    target_path.start_protocol == protocol.id):
-
-                    continue
-
-                protocol.set_value(source_path, previous_outputs_by_path[target_path])
-
-        logging.info('Executing protocol: {}'.format(protocol.id))
-
-        start_time = time.perf_counter()
-
-        try:
-            output_dictionary = protocol.execute(directory, available_resources)
         except Exception as e:
 
-            logging.info(f'Protocol failed to execute: {protocol.id}')
+            logging.info(f'Protocol failed to execute: {protocol_schema.id}')
 
             # Except the unexcepted...
             formatted_exception = traceback.format_exception(None, e, e.__traceback__)
@@ -1110,27 +1133,8 @@ class WorkflowGraph:
                                                    message='An unhandled exception '
                                                            'occurred: {}'.format(formatted_exception))
 
-            output_dictionary = exception
-
-        end_time = time.perf_counter()
-
-        logging.info('Protocol finished executing ({} ms): {}'.format((end_time-start_time)*1000, protocol.id))
-
-        try:
-
-            WorkflowGraph._save_protocol_output(output_dictionary_path, output_dictionary)
-
-        except TypeError as e:
-
-            formatted_exception = traceback.format_exception(None, e, e.__traceback__)
-
-            exception = PropertyEstimatorException(directory=directory,
-                                                   message='Could not save the output dictionary of {} ({}): {}'.format(
-                                                           protocol.id, output_dictionary_path, formatted_exception))
-
             WorkflowGraph._save_protocol_output(output_dictionary_path, exception)
-
-        return protocol.id, output_dictionary_path
+            return protocol_schema.id, output_dictionary_path
 
     @staticmethod
     def _gather_results(directory, property_to_return, value_reference, outputs_to_store,
@@ -1167,67 +1171,80 @@ class WorkflowGraph:
         return_object = CalculationLayerResult()
         return_object.property_id = property_to_return.id
 
-        results_by_id = {}
+        try:
+            results_by_id = {}
 
-        for protocol_id, protocol_result_path in protocol_result_paths:
+            for protocol_id, protocol_result_path in protocol_result_paths:
 
-            protocol_results = None
+                protocol_results = None
 
-            try:
+                try:
 
-                with open(protocol_result_path, 'r') as file:
-                    protocol_results = json.load(file, cls=TypedJSONDecoder)
+                    with open(protocol_result_path, 'r') as file:
+                        protocol_results = json.load(file, cls=TypedJSONDecoder)
 
-            except json.JSONDecodeError as e:
+                except json.JSONDecodeError as e:
 
-                formatted_exception = traceback.format_exception(None, e, e.__traceback__)
+                    formatted_exception = traceback.format_exception(None, e, e.__traceback__)
 
-                return PropertyEstimatorException(message='Could not load the output dictionary of {} ({}): {}'.format(
-                                                      protocol_id, protocol_result_path, formatted_exception))
+                    exception = PropertyEstimatorException(message=f'Could not load the output dictionary of '
+                                                                   f'{protocol_id} ({protocol_result_path}): '
+                                                                   f'{formatted_exception}')
 
-            # Make sure none of the protocols failed and we actually have a value
-            # and uncertainty.
-            if isinstance(protocol_results, PropertyEstimatorException):
+                    return_object.exception = exception
+                    return return_object
 
-                return_object.exception = protocol_results
-                return return_object
+                # Make sure none of the protocols failed and we actually have a value
+                # and uncertainty.
+                if isinstance(protocol_results, PropertyEstimatorException):
 
-            for output_path, output_value in protocol_results.items():
+                    return_object.exception = protocol_results
+                    return return_object
 
-                property_name, protocol_ids = ProtocolPath.to_components(output_path)
+                for output_path, output_value in protocol_results.items():
 
-                if len(protocol_ids) == 0 or (len(protocol_ids) > 0 and protocol_ids[0] != protocol_id):
-                    protocol_ids.insert(0, protocol_id)
+                    property_name, protocol_ids = ProtocolPath.to_components(output_path)
 
-                final_path = ProtocolPath(property_name, *protocol_ids)
-                results_by_id[final_path] = output_value
+                    if len(protocol_ids) == 0 or (len(protocol_ids) > 0 and protocol_ids[0] != protocol_id):
+                        protocol_ids.insert(0, protocol_id)
 
-        if target_uncertainty is not None and results_by_id[value_reference].uncertainty > target_uncertainty:
+                    final_path = ProtocolPath(property_name, *protocol_ids)
+                    results_by_id[final_path] = output_value
 
-            logging.info('The final uncertainty ({}) was not less than the target threshold ({}).'.format(
-                results_by_id[value_reference].uncertainty, target_uncertainty))
+            if target_uncertainty is not None and results_by_id[value_reference].uncertainty > target_uncertainty:
 
-            return None
+                logging.info('The final uncertainty ({}) was not less than the target threshold ({}).'.format(
+                    results_by_id[value_reference].uncertainty, target_uncertainty))
 
-        property_to_return.value = results_by_id[value_reference].value
-        property_to_return.uncertainty = results_by_id[value_reference].uncertainty
+                return None
 
-        return_object.calculated_property = property_to_return
-        return_object.data_directories_to_store = []
+            property_to_return.value = results_by_id[value_reference].value
+            property_to_return.uncertainty = results_by_id[value_reference].uncertainty
 
-        # TODO: At the moment it is assumed that the output of a WorkflowGraph is
-        #       a set of StoredSimulationData. This should be abstracted and made
-        #       more general in future if possible.
-        for output_to_store in outputs_to_store.values():
+            return_object.calculated_property = property_to_return
+            return_object.data_directories_to_store = []
 
-            results_directory = path.join(directory, f'results_{property_to_return.id}')
+            # TODO: At the moment it is assumed that the output of a WorkflowGraph is
+            #       a set of StoredSimulationData. This should be abstracted and made
+            #       more general in future if possible.
+            for output_to_store in outputs_to_store.values():
 
-            WorkflowGraph._store_simulation_data(results_directory,
-                                                 output_to_store,
-                                                 property_to_return,
-                                                 results_by_id)
+                results_directory = path.join(directory, f'results_{property_to_return.id}')
 
-            return_object.data_directories_to_store.append(results_directory)
+                WorkflowGraph._store_simulation_data(results_directory,
+                                                     output_to_store,
+                                                     property_to_return,
+                                                     results_by_id)
+
+                return_object.data_directories_to_store.append(results_directory)
+
+        except Exception as e:
+
+            formatted_exception = traceback.format_exception(None, e, e.__traceback__)
+
+            return_object.exception = PropertyEstimatorException(directory=directory,
+                                                                 message=f'An unhandled exception '
+                                                                         f'occurred: {formatted_exception}')
 
         return return_object
 
@@ -1250,7 +1267,10 @@ class WorkflowGraph:
             The results of the protocols which formed the property
             estimation workflow.
         """
-        from shutil import copyfile
+        from shutil import copy as file_copy
+
+        if not path.isdir(storage_directory):
+            makedirs(storage_directory)
 
         stored_object = StoredSimulationData()
 
@@ -1271,15 +1291,10 @@ class WorkflowGraph:
 
         _, statistics_file_name = path.split(results_by_id[output_to_store.statistics_file_path])
 
-        coordinate_file_path = path.join(storage_directory, coordinate_file_name)
-        trajectory_file_path = path.join(storage_directory, trajectory_file_name)
+        file_copy(results_by_id[output_to_store.coordinate_file_path], storage_directory)
+        file_copy(results_by_id[output_to_store.trajectory_file_path], storage_directory)
 
-        statistics_file_path = path.join(storage_directory, statistics_file_name)
-
-        copyfile(results_by_id[output_to_store.coordinate_file_path], coordinate_file_path)
-        copyfile(results_by_id[output_to_store.trajectory_file_path], trajectory_file_path)
-
-        copyfile(results_by_id[output_to_store.statistics_file_path], statistics_file_path)
+        file_copy(results_by_id[output_to_store.statistics_file_path], storage_directory)
 
         stored_object.coordinate_file_name = coordinate_file_name
         stored_object.trajectory_file_name = trajectory_file_name

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -1281,10 +1281,10 @@ class WorkflowGraph:
 
         copyfile(results_by_id[output_to_store.statistics_file_path], statistics_file_path)
 
-        stored_object.coordinate_path = coordinate_file_path
-        stored_object.trajectory_path = trajectory_file_path
+        stored_object.coordinate_file_name = coordinate_file_name
+        stored_object.trajectory_file_name = trajectory_file_name
 
-        stored_object.statistics_path = statistics_file_path
+        stored_object.statistics_file_name = statistics_file_name
 
         stored_object.statistical_inefficiency = results_by_id[output_to_store.statistical_inefficiency]
 


### PR DESCRIPTION
## Description
A PR to refactor the cached simulation storage so that workflows and calculation layers will simply create temporary directories filled with all of the data which is to be stored permanently, and it is up to the storage backend how that directory is converted into its final format (e.g. compressed into a database, or simply move the temp directory into a permanent location).

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Refactor the workflow to collate all data to store into a single directory
  - [x] Refactor the base calculation layer `await_results` method to pass the directory to the storage backend.
  - [x] Refactor the storage backend to deal now with directory paths when storing / retrieving simulation data.
  - [x] Write integration test for storage changes.
  - [x] Write integration test for reweighting to ensure compatibility.

## Status
- [x] Ready to go