### PR TITLE
Fix for LSF Backend Clogging Queue With Instantly Killed Workers

### DIFF
--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -16,7 +16,7 @@ from simtk import unit
 
 from .backends import PropertyEstimatorBackend, ComputeResources, QueueWorkerResources
 
-_logger = logging.getLogger(__name__)
+# _logger = logging.getLogger(__name__)
 
 
 class _ImprovedAdaptive(Adaptive):
@@ -45,8 +45,8 @@ class _ImprovedAdaptive(Adaptive):
 
         if total_occupancy / (total_cores + 1e-9) > self.startup_cost * 2:
 
-            _logger.info("CPU limit exceeded [%d occupancy / %d cores]",
-                         total_occupancy, total_cores)
+            # _logger.info("CPU limit exceeded [%d occupancy / %d cores]",
+            #              total_occupancy, total_cores)
 
             tasks_processing = 0
 
@@ -55,10 +55,10 @@ class _ImprovedAdaptive(Adaptive):
 
                 if tasks_processing > total_cores:
 
-                    _logger.info(
-                        "pending tasks exceed number of cores "
-                        "[%d tasks / %d cores]",
-                        tasks_processing, total_cores)
+                    # _logger.info(
+                    #     "pending tasks exceed number of cores "
+                    #     "[%d tasks / %d cores]",
+                    #     tasks_processing, total_cores)
 
                     return True
 

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -182,11 +182,27 @@ class PropertyCalculationLayer:
 
                 matches = [x for x in server_request.queued_properties if x.id == returned_output.property_id]
 
-                if len(matches) != 1:
-                    raise ValueError(f'A property id ({returned_output.property_id}) conflict occurred.')
-
                 for match in matches:
                     server_request.queued_properties.remove(match)
+
+                if len(matches) > 1:
+                    raise ValueError(f'A property id ({returned_output.property_id}) conflict occurred.')
+
+                elif len(matches) == 0:
+
+                    logging.info('A calculation layer returned results for a property not in the '
+                                 'queue. This sometimes and expectedly occurs when using queue based '
+                                 'calculation backends, but should be investigated.')
+
+                    continue
+
+                if returned_output.calculated_property is None and returned_output.exception is None:
+
+                    logging.info('A calculation layer did not return an estimated property nor did it'
+                                 'raise an Exception. This sometimes and expectedly occurs when using '
+                                 'queue based calculation backends, but should be investigated.')
+
+                    continue
 
                 substance_id = returned_output.calculated_property.substance.identifier
 

--- a/propertyestimator/storage/localfile.py
+++ b/propertyestimator/storage/localfile.py
@@ -74,6 +74,9 @@ class LocalFileStorage(PropertyEstimatorStorage):
 
     def store_simulation_data(self, substance_id, simulation_data_directory):
 
+        if not path.isdir(simulation_data_directory):
+            raise ValueError(f'The directory ({simulation_data_directory}) to store does not exist.')
+
         unique_id = super(LocalFileStorage, self).store_simulation_data(substance_id,
                                                                         simulation_data_directory)
 

--- a/propertyestimator/workflow/protocols.py
+++ b/propertyestimator/workflow/protocols.py
@@ -1832,6 +1832,10 @@ class ReweightWithMBARProtocol(BaseProtocol):
                                            observables=np.transpose(observables))
 
             if effective_samples < self._required_effective_samples:
+
+                logging.info(f'{self.id}: There was not enough effective samples '
+                             f'to reweight - {effective_samples} < {self._required_effective_samples}')
+
                 uncertainty = sys.float_info.max
 
             self._value = EstimatedQuantity(value * observable_unit,
@@ -1847,6 +1851,10 @@ class ReweightWithMBARProtocol(BaseProtocol):
             uncertainty = uncertainties['observables']
 
             if effective_samples < self._required_effective_samples:
+
+                logging.info(f'{self.id}: There was not enough effective samples '
+                             f'to reweight - {effective_samples} < {self._required_effective_samples}')
+
                 uncertainty = sys.float_info.max
 
             self._value = EstimatedQuantity(values['observables'] * observable_unit,


### PR DESCRIPTION
## Description
A PR to implement the fix mentioned on the [dask distributed repo](https://github.com/dask/distributed/issues/2329) which was causing the dask-jobqueue cluster objects to continuously push workers into the queue which were not needed (e.g when only a single task was left to execute, the cluster object still kept trying to fill the queue up to `max_workers`)

## Status
- [x] Ready to review
- [x] Ready to go