### PR TITLE
Initial Yank Host-Guest Binding Affinity Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ examples/property_estimator/working_directory/
 
 propertyestimator/data/properties/JCT/
 *dask-worker-space/
+
+integration_tests*
+
+propertyestimator/tests/**/*dat

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,15 @@ install:
 - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/test_env.yaml
 - conda activate test
 
-# Temporary addition until version 0.3.0 is released.
+# Temporary addition until version 0.3.0 of the OFF toolkit is released.
 - conda config --add channels omnia --add channels conda-forge
 - conda install --yes --only-deps openforcefield
 - pip install git+https://github.com/openforcefield/openforcefield.git@0.3.0-branch
+
+# Temporary addition until a version of yank which includes trailblaze checkpoints
+# is released
+- conda install --yes --only-deps yank
+- pip install git+https://github.com/choderalab/yank.git@trailblaze_checkpoint
 
 - python setup.py develop --no-deps
 script:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -31,5 +31,5 @@ dependencies:
   - coverage >=4.4
   - uncertainties
   - openmmtools
-  - yank
+#  - yank
   - pyyaml

--- a/propertyestimator/data/forcefield/tip3p.offxml
+++ b/propertyestimator/data/forcefield/tip3p.offxml
@@ -7,7 +7,7 @@
   <Author>J. D. Chodera, MSKCC; A. Rizzi, Weill Cornell; C. C. Bannan, UC Irvine</Author>
 
   <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
-    <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968"/>
+    <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="3.1507" epsilon="0.1521"/>
     <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" id="n2" sigma="1" epsilon="0"/>
   </vdW>
 

--- a/propertyestimator/data/forcefield/tip3p.offxml
+++ b/propertyestimator/data/forcefield/tip3p.offxml
@@ -6,20 +6,13 @@
   <Date>2019-04-04</Date>
   <Author>J. D. Chodera, MSKCC; A. Rizzi, Weill Cornell; C. C. Bannan, UC Irvine</Author>
 
-  <!-- SMIRNOFF file implementing TIP3P water model. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstroms" cutoff="9.0" cutoff_unit="angstroms" long_range_dispersion="isotropic">
-    <!-- TIP3P water oxygen with charge override -->
-    <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
-    <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968" charge="-0.834"/>
-    <!-- TIP3P water hydrogen with charge override -->
-    <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
-    <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" id="n2" sigma="1" epsilon="0" charge="0.417"/>
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch_width="1.0" switch_width_unit="angstrom" cutoff="9.0" cutoff_unit="angstrom" method="cutoff">
+    <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968"/>
+    <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" id="n2" sigma="1" epsilon="0"/>
   </vdW>
 
   <Constraints distance_unit="angstroms">
-    <!-- constrain water O-H bond to equilibrium bond length (overrides earlier constraint) -->
     <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c1" distance="0.9572"/>
-    <!-- constrain water H...H, calculating equilibrium length from H-O-H equilibrium angle and H-O equilibrium bond lengths -->
     <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c2" distance="1.5139006545247014"/>
   </Constraints>
 

--- a/propertyestimator/properties/__init__.py
+++ b/propertyestimator/properties/__init__.py
@@ -1,5 +1,5 @@
-from .properties import PropertyPhase, PhysicalProperty, MeasurementSource, CalculationSource
-
+from .binding import HostGuestBindingAffinity
 from .density import Density
 from .dielectric import DielectricConstant
 from .enthalpy import EnthalpyOfMixing
+from .properties import PropertyPhase, PhysicalProperty, MeasurementSource, CalculationSource

--- a/propertyestimator/properties/__init__.py
+++ b/propertyestimator/properties/__init__.py
@@ -1,5 +1,5 @@
+from .properties import PropertyPhase, PhysicalProperty, MeasurementSource, CalculationSource
 from .binding import HostGuestBindingAffinity
 from .density import Density
 from .dielectric import DielectricConstant
 from .enthalpy import EnthalpyOfMixing
-from .properties import PropertyPhase, PhysicalProperty, MeasurementSource, CalculationSource

--- a/propertyestimator/properties/binding.py
+++ b/propertyestimator/properties/binding.py
@@ -129,10 +129,9 @@ class HostGuestBindingAffinity(PhysicalProperty):
 
         yank_protocol.thermodynamic_state = ProtocolPath('thermodynamic_state', 'global')
 
-        yank_protocol.number_of_iterations = 1
-
-        yank_protocol.steps_per_iteration = 1000000
-        yank_protocol.checkpoint_interval = 1
+        yank_protocol.number_of_iterations = 2000
+        yank_protocol.steps_per_iteration = 500
+        yank_protocol.checkpoint_interval = 10
 
         yank_protocol.verbose = True
 

--- a/propertyestimator/properties/binding.py
+++ b/propertyestimator/properties/binding.py
@@ -1,0 +1,169 @@
+"""
+A collection of density physical property definitions.
+"""
+
+from propertyestimator.properties import PhysicalProperty
+from propertyestimator.properties.plugins import register_estimable_property
+from propertyestimator.protocols import coordinates, forcefield, simulation, miscellaneous
+from propertyestimator.substances import Substance
+from propertyestimator.workflow.schemas import WorkflowSchema
+from propertyestimator.workflow.utils import ProtocolPath
+
+
+@register_estimable_property()
+class HostGuestBindingAffinity(PhysicalProperty):
+    """A class representation of a host-guest binding affinity property"""
+
+    @property
+    def multi_component_property(self):
+        """Returns whether this property is dependant on properties of the
+        full mixed substance, or whether it is also dependant on the properties
+        of the individual components also.
+        """
+        return False
+
+    @staticmethod
+    def get_default_workflow_schema(calculation_layer, options=None):
+
+        if calculation_layer == 'SimulationLayer':
+            return HostGuestBindingAffinity.get_default_simulation_workflow_schema(options)
+
+        return None
+
+    @staticmethod
+    def get_default_simulation_workflow_schema(options=None):
+        """Returns the default workflow to use when estimating this property
+        from direct simulations.
+
+        Parameters
+        ----------
+        options: WorkflowOptions
+            The default options to use when setting up the estimation workflow.
+
+        Returns
+        -------
+        WorkflowSchema
+            The schema to follow when estimating this property.
+        """
+
+        schema = WorkflowSchema(property_type=HostGuestBindingAffinity.__name__)
+        schema.id = '{}{}'.format(HostGuestBindingAffinity.__name__, 'Schema')
+
+        # Initial coordinate and topology setup.
+        filter_ligand = miscellaneous.FilterSubstanceByRole('filter_ligand')
+        filter_ligand.input_substance = ProtocolPath('substance', 'global')
+
+        filter_ligand.component_role = Substance.ComponentRole.Ligand
+        # We only support substances with a single guest ligand.
+        filter_ligand.expected_components = 1
+
+        schema.protocols[filter_ligand.id] = filter_ligand.schema
+
+        # Construct the protocols which will (for now) take as input a set of host coordinates,
+        # and generate a set of charges for them.
+        filter_receptor = miscellaneous.FilterSubstanceByRole('filter_receptor')
+        filter_receptor.input_substance = ProtocolPath('substance', 'global')
+
+        filter_receptor.component_role = Substance.ComponentRole.Receptor
+        # We only support substances with a single host receptor.
+        filter_receptor.expected_components = 1
+
+        schema.protocols[filter_receptor.id] = filter_receptor.schema
+
+        # Perform docking to position the guest within the host.
+        perform_docking = coordinates.BuildDockedCoordinates('perform_docking')
+
+        perform_docking.ligand_substance = ProtocolPath('filtered_substance', filter_ligand.id)
+        perform_docking.receptor_coordinate_file = ProtocolPath('receptor_mol2', 'global')
+
+        schema.protocols[perform_docking.id] = perform_docking.schema
+
+        # Solvate the docked structure using packmol
+        filter_solvent = miscellaneous.FilterSubstanceByRole('filter_solvent')
+        filter_solvent.input_substance = ProtocolPath('substance', 'global')
+        filter_solvent.component_role = Substance.ComponentRole.Solvent
+
+        schema.protocols[filter_solvent.id] = filter_solvent.schema
+
+        solvate_complex = coordinates.SolvateExistingStructure('solvate_complex')
+        solvate_complex.max_molecules = 1000
+
+        solvate_complex.substance = ProtocolPath('filtered_substance', filter_solvent.id)
+        solvate_complex.solute_coordinate_file = ProtocolPath('docked_complex_coordinate_path', perform_docking.id)
+
+        schema.protocols[solvate_complex.id] = solvate_complex.schema
+
+        # Assign force field parameters to the solvated complex system.
+        build_solvated_complex_system = forcefield.BuildSmirnoffSystem('build_solvated_complex_system')
+
+        build_solvated_complex_system.force_field_path = ProtocolPath('force_field_path', 'global')
+
+        build_solvated_complex_system.coordinate_file_path = ProtocolPath('coordinate_file_path', solvate_complex.id)
+        build_solvated_complex_system.substance = ProtocolPath('substance', 'global')
+
+        build_solvated_complex_system.charged_molecule_paths = [ProtocolPath('receptor_mol2', 'global')]
+
+        schema.protocols[build_solvated_complex_system.id] = build_solvated_complex_system.schema
+
+        # Solvate the ligand using packmol
+        solvate_ligand = coordinates.SolvateExistingStructure('solvate_ligand')
+        solvate_ligand.max_molecules = 1000
+
+        solvate_ligand.substance = ProtocolPath('filtered_substance', filter_solvent.id)
+        solvate_ligand.solute_coordinate_file = ProtocolPath('docked_ligand_coordinate_path', perform_docking.id)
+
+        schema.protocols[solvate_ligand.id] = solvate_ligand.schema
+
+        # Assign force field parameters to the solvated ligand system.
+        build_solvated_ligand_system = forcefield.BuildSmirnoffSystem('build_solvated_ligand_system')
+
+        build_solvated_ligand_system.force_field_path = ProtocolPath('force_field_path', 'global')
+
+        build_solvated_ligand_system.coordinate_file_path = ProtocolPath('coordinate_file_path', solvate_ligand.id)
+        build_solvated_ligand_system.substance = ProtocolPath('substance', 'global')
+
+        schema.protocols[build_solvated_ligand_system.id] = build_solvated_ligand_system.schema
+
+        # Employ YANK to estimate the binding free energy.
+        yank_protocol = simulation.LigandReceptorYankProtocol('yank_protocol')
+
+        yank_protocol.thermodynamic_state = ProtocolPath('thermodynamic_state', 'global')
+
+        yank_protocol.number_of_iterations = 1
+
+        yank_protocol.steps_per_iteration = 1000000
+        yank_protocol.checkpoint_interval = 1
+
+        yank_protocol.verbose = True
+
+        yank_protocol.force_field_path = ProtocolPath('force_field_path', 'global')
+
+        yank_protocol.ligand_residue_name = ProtocolPath('ligand_residue_name', perform_docking.id)
+
+        yank_protocol.solvated_ligand_coordinates = ProtocolPath('coordinate_file_path', solvate_ligand.id)
+        yank_protocol.solvated_ligand_system = ProtocolPath('system_path', build_solvated_ligand_system.id)
+
+        yank_protocol.solvated_complex_coordinates = ProtocolPath('coordinate_file_path', solvate_complex.id)
+        yank_protocol.solvated_complex_system = ProtocolPath('system_path', build_solvated_complex_system.id)
+
+        schema.protocols[yank_protocol.id] = yank_protocol.schema
+
+        # Define where the final values come from.
+        schema.final_value_source = ProtocolPath('estimated_free_energy', yank_protocol.id)
+
+        # output_to_store = WorkflowOutputToStore()
+        #
+        # output_to_store.trajectory_file_path = ProtocolPath('output_trajectory_path',
+        #                                                     extract_uncorrelated_trajectory.id)
+        # output_to_store.coordinate_file_path = ProtocolPath('output_coordinate_file',
+        #                                                     converge_uncertainty.id, npt_production.id)
+        #
+        # output_to_store.statistics_file_path = ProtocolPath('output_statistics_path',
+        #                                                     extract_uncorrelated_statistics.id)
+        #
+        # output_to_store.statistical_inefficiency = ProtocolPath('statistical_inefficiency', converge_uncertainty.id,
+        #                                                                                     extract_density.id)
+        #
+        # schema.outputs_to_store = {'full_system': output_to_store}
+
+        return schema

--- a/propertyestimator/properties/binding.py
+++ b/propertyestimator/properties/binding.py
@@ -138,6 +138,7 @@ class HostGuestBindingAffinity(PhysicalProperty):
         yank_protocol.force_field_path = ProtocolPath('force_field_path', 'global')
 
         yank_protocol.ligand_residue_name = ProtocolPath('ligand_residue_name', perform_docking.id)
+        yank_protocol.receptor_residue_name = ProtocolPath('receptor_residue_name', perform_docking.id)
 
         yank_protocol.solvated_ligand_coordinates = ProtocolPath('coordinate_file_path', solvate_ligand.id)
         yank_protocol.solvated_ligand_system = ProtocolPath('system_path', build_solvated_ligand_system.id)

--- a/propertyestimator/properties/properties.py
+++ b/propertyestimator/properties/properties.py
@@ -190,6 +190,8 @@ class PhysicalProperty(TypedBaseModel):
             'uncertainty': self.uncertainty,
     
             'source': self.source,
+
+            'metadata': self._metadata
         }
 
     def __setstate__(self, state):
@@ -205,6 +207,8 @@ class PhysicalProperty(TypedBaseModel):
         self.uncertainty = state['uncertainty']
 
         self.source = state['source']
+
+        self._metadata = state['metadata']
 
     @property
     def temperature(self):

--- a/propertyestimator/protocols/forcefield.py
+++ b/propertyestimator/protocols/forcefield.py
@@ -99,6 +99,11 @@ class BuildSmirnoffSystem(BaseProtocol):
         These are solely to be used as a work around until library charges
         are fully implemented in the openforcefield toolkit.
 
+        Todos
+        -----
+        Remove this method when library charges are fully implemented in
+        the openforcefield toolkit.
+
         Returns
         -------
         list of openforcefield.topology.Molecule

--- a/propertyestimator/protocols/forcefield.py
+++ b/propertyestimator/protocols/forcefield.py
@@ -3,6 +3,7 @@ A collection of protocols for assigning force field parameters to molecular syst
 """
 
 import logging
+from enum import Enum
 from os import path
 
 import numpy as np
@@ -20,6 +21,16 @@ from propertyestimator.workflow.protocols import BaseProtocol
 class BuildSmirnoffSystem(BaseProtocol):
     """Parametrise a set of molecules with a given smirnoff force field.
     """
+    class WaterModel(Enum):
+        """An enum which describes which water model is being
+        used, so that correct charges can be applied.
+
+        Warnings
+        --------
+        This is only a temporary addition until library charges
+        are introduced into the openforcefield toolkit.
+        """
+        TIP3P = 'TIP3P'
 
     @protocol_input(str)
     def force_field_path(self, value):
@@ -46,6 +57,18 @@ class BuildSmirnoffSystem(BaseProtocol):
         """The composition of the system."""
         pass
 
+    @protocol_input(WaterModel)
+    def water_model(self):
+        """The water model to apply, if any water molecules
+        are present.
+
+        Warnings
+        --------
+        This is only a temporary addition until library charges
+        are introduced into the openforcefield toolkit.
+        """
+        pass
+
     @protocol_output(str)
     def system_path(self):
         """The assigned system."""
@@ -59,6 +82,8 @@ class BuildSmirnoffSystem(BaseProtocol):
         self._force_field_path = None
         self._coordinate_file_path = None
         self._substance = None
+
+        self._water_model = BuildSmirnoffSystem.WaterModel.TIP3P
 
         self._charged_molecule_paths = {}
 
@@ -94,7 +119,10 @@ class BuildSmirnoffSystem(BaseProtocol):
         chlorine = Molecule.from_smiles('[Cl-]')
         chlorine.partial_charges = np.array([-1.0]) * unit.elementary_charge
 
-        return [sodium, potassium, calcium, chlorine]
+        water = Molecule.from_smiles('O')
+        water.partial_charges = np.array([-0.834, 0.417, 0.417]) * unit.elementary_charge
+
+        return [sodium, potassium, calcium, chlorine, water]
 
     def execute(self, directory, available_resources):
 

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -8,7 +8,6 @@ import traceback
 from enum import Enum
 from os import path
 
-import numpy as np
 import yaml
 from simtk import unit, openmm
 from simtk.openmm import app
@@ -468,26 +467,28 @@ class BaseYankProtocol(BaseProtocol):
         to a yaml file and passed to YANK. In most cases, this should
         just be passing force field settings over, such as PME settings.
 
-        # TODO: Again, is this neccessary if we are using system.xml
-        #       files...
+        TODO: Check with Andrea which entries need to present here when
+              using OMM system.xml files.
 
         Returns
         -------
         dict of str and Any
             A yaml compatible dictionary of YANK solvents.
         """
+        # import numpy as np
+
         from openforcefield.typing.engines.smirnoff.forcefield import ForceField
-        from openforcefield.utils import quantity_to_string
+        # from openforcefield.utils import quantity_to_string
 
         force_field = ForceField(self._force_field_path)
-
-        if not np.isclose(force_field.get_parameter_handler('Electrostatics').cutoff.value_in_unit(unit.angstrom),
-                          force_field.get_parameter_handler('vdW').cutoff.value_in_unit(unit.angstrom)):
-
-            raise ValueError('The electrostatic and vdW cutoffs must be identical.')
-
-        cutoff = force_field.get_parameter_handler('vdW').cutoff
-        switch_distance = force_field.get_parameter_handler('vdW').switch_width
+        #
+        # if not np.isclose(force_field.get_parameter_handler('Electrostatics').cutoff.value_in_unit(unit.angstrom),
+        #                   force_field.get_parameter_handler('vdW').cutoff.value_in_unit(unit.angstrom)):
+        #
+        #     raise ValueError('The electrostatic and vdW cutoffs must be identical.')
+        #
+        # cutoff = force_field.get_parameter_handler('vdW').cutoff
+        # switch_distance = force_field.get_parameter_handler('vdW').switch_width
 
         charge_method = force_field.get_parameter_handler('Electrostatics').method
 
@@ -497,9 +498,9 @@ class BaseYankProtocol(BaseProtocol):
         # Do we need to include `ewald_error_tolerance`?
         return {'default': {
             'nonbonded_method': charge_method,
-            'nonbonded_cutoff': quantity_to_string(cutoff.in_units_of(unit.nanometers)),
-
-            'switch_distance': quantity_to_string(switch_distance.in_units_of(unit.nanometers)),
+            # 'nonbonded_cutoff': quantity_to_string(cutoff.in_units_of(unit.nanometers)),
+            #
+            # 'switch_distance': quantity_to_string(switch_distance.in_units_of(unit.nanometers)),
         }}
 
     def _get_system_dictionary(self):

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -9,9 +9,6 @@ from os import path
 
 import numpy as np
 import yaml
-from simtk import unit, openmm
-from simtk.openmm import app
-
 from propertyestimator.thermodynamics import ThermodynamicState, Ensemble
 from propertyestimator.utils import statistics
 from propertyestimator.utils.exceptions import PropertyEstimatorException
@@ -21,6 +18,8 @@ from propertyestimator.utils.utils import temporarily_change_directory
 from propertyestimator.workflow.decorators import protocol_input, protocol_output, MergeBehaviour
 from propertyestimator.workflow.plugins import register_calculation_protocol
 from propertyestimator.workflow.protocols import BaseProtocol
+from simtk import unit, openmm
+from simtk.openmm import app
 
 
 @register_calculation_protocol()
@@ -569,7 +568,7 @@ class BaseYankProtocol(BaseProtocol):
 
         from yank.analyze import extract_trajectory
 
-        mdtraj_trajectory = extract_trajectory(checkpoint_path, state_index=0)
+        mdtraj_trajectory = extract_trajectory(checkpoint_path, state_index=0, image_molecules=True)
         mdtraj_trajectory.save_dcd(output_trajectory_path)
 
     @staticmethod

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -437,8 +437,8 @@ class BaseYankProtocol(BaseProtocol):
             toolkit_enum = ComputeResources.GPUToolkit(available_resources.preferred_gpu_toolkit)
 
             # A platform which runs on GPUs has been requested.
-            platform_name = ('CUDA' if toolkit_enum == ComputeResources.GPUToolkit.CUDA else
-                                                       ComputeResources.GPUToolkit.OpenCL)
+            platform_name = 'CUDA' if toolkit_enum == ComputeResources.GPUToolkit.CUDA else \
+                                                      ComputeResources.GPUToolkit.OpenCL
 
         return {
             'verbose': self._verbose,
@@ -813,7 +813,10 @@ class LigandReceptorYankProtocol(BaseYankProtocol):
         shutil.copyfile(self._solvated_complex_coordinates, path.join(directory, self._local_complex_coordinates))
         shutil.copyfile(self._solvated_complex_system, path.join(directory, self._local_complex_system))
 
-        super(LigandReceptorYankProtocol, self).execute(directory, available_resources)
+        result = super(LigandReceptorYankProtocol, self).execute(directory, available_resources)
+
+        if isinstance(result, PropertyEstimatorException):
+            return result
 
         ligand_yank_path = path.join(directory, 'experiments', 'solvent.nc')
         complex_yank_path = path.join(directory, 'experiments', 'complex.nc')

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -8,6 +8,7 @@ import traceback
 from os import path
 
 import numpy as np
+import yaml
 from simtk import unit, openmm
 from simtk.openmm import app
 
@@ -580,11 +581,11 @@ class BaseYankProtocol(BaseProtocol):
 
     def execute(self, directory, available_resources):
 
-        # yaml_filename = path.join(directory, 'yank.yaml')
-        #
-        # # Create the yank yaml input file from a dictionary of options.
-        # with open(yaml_filename, 'w') as file:
-        #     yaml.dump(self._get_full_input_dictionary(), file)
+        yaml_filename = path.join(directory, 'yank.yaml')
+
+        # Create the yank yaml input file from a dictionary of options.
+        with open(yaml_filename, 'w') as file:
+            yaml.dump(self._get_full_input_dictionary(), file)
 
         # Yank is not safe to be called from anything other than the main thread.
         # If the current thread is not detected as the main one, then yank should

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -3,9 +3,9 @@ A collection of protocols for running molecular simulations.
 """
 
 import logging
-import yaml
 from os import path
 
+import yaml
 from simtk import unit, openmm
 from simtk.openmm import app
 
@@ -184,7 +184,7 @@ class RunOpenMMSimulation(BaseProtocol):
     def execute(self, directory, available_resources):
 
         temperature = self._thermodynamic_state.temperature
-        pressure = self._thermodynamic_state.pressure
+        pressure = None if self._ensemble == Ensemble.NVT else self._thermodynamic_state.pressure
 
         if temperature is None:
 
@@ -218,8 +218,6 @@ class RunOpenMMSimulation(BaseProtocol):
                                               message='Simulation failed: {}'.format(e))
 
         # Save the newly generated statistics data as a pandas csv file.
-        pressure = None if self._ensemble == Ensemble.NVT else self._thermodynamic_state.pressure
-
         working_statistics = statistics.StatisticsArray.from_openmm_csv(self._temporary_statistics_path, pressure)
         working_statistics.save_as_pandas_csv(self._statistics_file_path)
 

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -431,8 +431,14 @@ class BaseYankProtocol(BaseProtocol):
         platform_name = 'CPU'
 
         if available_resources.number_of_gpus > 0:
+
             # A platform which runs on GPUs has been requested.
-            platform_name = 'CUDA' if available_resources.preferred_gpu_toolkit == 'CUDA' else 'OpenCL'
+            from propertyestimator.backends import ComputeResources
+            toolkit_enum = ComputeResources.GPUToolkit(available_resources.preferred_gpu_toolkit)
+
+            # A platform which runs on GPUs has been requested.
+            platform_name = ('CUDA' if toolkit_enum == ComputeResources.GPUToolkit.CUDA else
+                                                       ComputeResources.GPUToolkit.OpenCL)
 
         return {
             'verbose': self._verbose,

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -548,6 +548,21 @@ class BaseYankProtocol(BaseProtocol):
 
     @staticmethod
     def _run_yank(directory):
+        """Runs YANK within the specified directory which contains a `yank.yaml`
+        input file.
+
+        Parameters
+        ----------
+        directory: str
+            The directory within which to run yank.
+
+        Returns
+        -------
+        simtk.unit.Quantity
+            The free energy returned by yank.
+        simtk.unit.Quantity
+            The uncertainty in the free energy returned by yank.
+        """
 
         from yank.experiment import ExperimentBuilder
         from yank.analyze import ExperimentAnalyzer
@@ -566,6 +581,29 @@ class BaseYankProtocol(BaseProtocol):
 
     @staticmethod
     def _run_yank_as_process(queue, directory):
+        """A wrapper around the `_run_yank` method which takes
+        a `multiprocessing.Queue` as input, thereby allowing it
+        to be launched from a separate process and still return
+        it's output back to the main process.
+
+        Parameters
+        ----------
+        queue: multiprocessing.Queue
+            The queue object which will communicate with the
+            launched process.
+        directory: str
+            The directory within which to run yank.
+
+        Returns
+        -------
+        simtk.unit.Quantity
+            The free energy returned by yank.
+        simtk.unit.Quantity
+            The uncertainty in the free energy returned by yank.
+        str, optional
+            The stringified errors which occurred on the other process,
+            or `None` if no exceptions were raised.
+        """
 
         free_energy = None
         free_energy_uncertainty = None

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -519,9 +519,14 @@ class BaseYankProtocol(BaseProtocol):
         """
         raise NotImplementedError()
 
-    def _get_full_input_dictionary(self):
+    def _get_full_input_dictionary(self, available_resources):
         """Returns a dictionary of the full YANK inputs which will be serialized
         to a yaml file and passed to YANK
+
+        Parameters
+        ----------
+        available_resources: ComputeResources
+            The resources available to execute on.
 
         Returns
         -------
@@ -536,7 +541,7 @@ class BaseYankProtocol(BaseProtocol):
         protocol_key = next(iter(protocol_dictionary))
 
         return {
-            'options': self._get_options_dictionary(),
+            'options': self._get_options_dictionary(available_resources),
 
             'solvents': self._get_solvent_dictionary(),
 
@@ -649,7 +654,7 @@ class BaseYankProtocol(BaseProtocol):
 
         # Create the yank yaml input file from a dictionary of options.
         with open(yaml_filename, 'w') as file:
-            yaml.dump(self._get_full_input_dictionary(), file)
+            yaml.dump(self._get_full_input_dictionary(available_resources), file)
 
         # Yank is not safe to be called from anything other than the main thread.
         # If the current thread is not detected as the main one, then yank should

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -467,40 +467,21 @@ class BaseYankProtocol(BaseProtocol):
         to a yaml file and passed to YANK. In most cases, this should
         just be passing force field settings over, such as PME settings.
 
-        TODO: Check with Andrea which entries need to present here when
-              using OMM system.xml files.
-
         Returns
         -------
         dict of str and Any
             A yaml compatible dictionary of YANK solvents.
         """
-        # import numpy as np
-
         from openforcefield.typing.engines.smirnoff.forcefield import ForceField
-        # from openforcefield.utils import quantity_to_string
-
         force_field = ForceField(self._force_field_path)
-        #
-        # if not np.isclose(force_field.get_parameter_handler('Electrostatics').cutoff.value_in_unit(unit.angstrom),
-        #                   force_field.get_parameter_handler('vdW').cutoff.value_in_unit(unit.angstrom)):
-        #
-        #     raise ValueError('The electrostatic and vdW cutoffs must be identical.')
-        #
-        # cutoff = force_field.get_parameter_handler('vdW').cutoff
-        # switch_distance = force_field.get_parameter_handler('vdW').switch_width
 
         charge_method = force_field.get_parameter_handler('Electrostatics').method
 
         if charge_method.lower() != 'pme':
             raise ValueError('Currently only PME electrostatics are supported.')
 
-        # Do we need to include `ewald_error_tolerance`?
         return {'default': {
             'nonbonded_method': charge_method,
-            # 'nonbonded_cutoff': quantity_to_string(cutoff.in_units_of(unit.nanometers)),
-            #
-            # 'switch_distance': quantity_to_string(switch_distance.in_units_of(unit.nanometers)),
         }}
 
     def _get_system_dictionary(self):

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -274,7 +274,7 @@ class Substance(TypedBaseModel):
         def identifier(self):
             return f'({int(round(self._value)):d})'
 
-        def __init__(self, value):
+        def __init__(self, value=1):
             """Constructs a new ExactAmount object.
 
             Parameters

--- a/propertyestimator/tests/test_utils/test_packmol.py
+++ b/propertyestimator/tests/test_utils/test_packmol.py
@@ -2,7 +2,6 @@
 Units tests for propertyestimator.utils.packmol
 """
 import pytest
-
 from simtk import unit
 
 from propertyestimator.utils import create_molecule_from_smiles
@@ -48,9 +47,9 @@ def test_packmol_packbox():
     topology, positions = packmol.pack_box(molecules, [10], box_size=20*unit.angstrom)
     _validate_water_results(topology, positions)
 
-    assert topology.getPeriodicBoxVectors()[0] == (20, 0, 0) * unit.angstrom
-    assert topology.getPeriodicBoxVectors()[1] == (0, 20, 0) * unit.angstrom
-    assert topology.getPeriodicBoxVectors()[2] == (0, 0, 20) * unit.angstrom
+    assert topology.getPeriodicBoxVectors()[0] == (22, 0, 0) * unit.angstrom
+    assert topology.getPeriodicBoxVectors()[1] == (0, 22, 0) * unit.angstrom
+    assert topology.getPeriodicBoxVectors()[2] == (0, 0, 22) * unit.angstrom
 
     with pytest.raises(ValueError):
         packmol.pack_box(molecules, [10, 20], box_size=20*unit.angstrom)

--- a/propertyestimator/tests/utils.py
+++ b/propertyestimator/tests/utils.py
@@ -3,6 +3,7 @@ from simtk import unit
 from propertyestimator.properties import PropertyPhase, CalculationSource
 from propertyestimator.substances import Substance
 from propertyestimator.thermodynamics import ThermodynamicState
+from propertyestimator.utils import get_data_filename
 
 
 def create_dummy_property(property_class):
@@ -21,4 +22,34 @@ def create_dummy_property(property_class):
     
     dummy_property.source = CalculationSource(fidelity='dummy', provenance={})
 
+    # Make sure the property has the meta data required for more
+    # involved properties.
+    dummy_property.metadata = {
+        'receptor_mol2': 'unknown_path.mol2'
+    }
+
     return dummy_property
+
+
+def build_tip3p_smirnoff_force_field():
+    """Combines the smirnoff99Frosst and tip3p offxml files
+    into a single one which can be consumed by the property
+    estimator.
+
+    Returns
+    -------
+    str
+        The file path to the combined force field file.
+    """
+    from openforcefield.typing.engines.smirnoff import ForceField
+    
+    smirnoff_force_field_path = get_data_filename('forcefield/smirnoff99Frosst.offxml')
+    tip3p_force_field_path = get_data_filename('forcefield/tip3p.offxml')
+
+    smirnoff_force_field_with_tip3p = ForceField(smirnoff_force_field_path,
+                                                 tip3p_force_field_path)
+
+    force_field_path = 'smirnoff99Frosst_tip3p.offxml'
+    smirnoff_force_field_with_tip3p.to_file(force_field_path)
+
+    return force_field_path

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -26,8 +26,8 @@ def setup_platform_with_resources(compute_resources):
         toolkit_enum = ComputeResources.GPUToolkit(compute_resources.preferred_gpu_toolkit)
 
         # A platform which runs on GPUs has been requested.
-        platform_name = ('CUDA' if toolkit_enum == ComputeResources.GPUToolkit.CUDA else
-                                                   ComputeResources.GPUToolkit.OpenCL)
+        platform_name = 'CUDA' if toolkit_enum == ComputeResources.GPUToolkit.CUDA else \
+                                                  ComputeResources.GPUToolkit.OpenCL
 
         # noinspection PyCallByClass,PyTypeChecker
         platform = Platform.getPlatformByName(platform_name)

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -36,7 +36,7 @@ def setup_platform_with_resources(compute_resources):
 
             property_platform_name = platform_name
 
-            if compute_resources.preferred_gpu_toolkit == 'CUDA':
+            if toolkit_enum == ComputeResources.GPUToolkit.CUDA:
                 property_platform_name = platform_name.lower().capitalize()
 
             platform.setPropertyDefaultValue(property_platform_name + 'DeviceIndex',

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -22,8 +22,12 @@ def setup_platform_with_resources(compute_resources):
     # Setup the requested platform:
     if compute_resources.number_of_gpus > 0:
 
+        from propertyestimator.backends import ComputeResources
+        toolkit_enum = ComputeResources.GPUToolkit(compute_resources.preferred_gpu_toolkit)
+
         # A platform which runs on GPUs has been requested.
-        platform_name = 'CUDA' if compute_resources.preferred_gpu_toolkit == 'CUDA' else 'OpenCL'
+        platform_name = ('CUDA' if toolkit_enum == ComputeResources.GPUToolkit.CUDA else
+                                                   ComputeResources.GPUToolkit.OpenCL)
 
         # noinspection PyCallByClass,PyTypeChecker
         platform = Platform.getPlatformByName(platform_name)

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -19,6 +19,8 @@ import numpy as np
 from simtk import openmm
 from simtk import unit
 
+from propertyestimator.utils.utils import temporarily_change_directory
+
 PACKMOL_PATH = find_executable("packmol") or shutil.which("packmol") or \
                None if 'PACKMOL' not in os.environ else os.environ['PACKMOL']
 
@@ -111,21 +113,39 @@ def pack_box(molecules,
         os.mkdir(working_directory)
 
     # Create PDB files for all components.
-    pdb_filenames = list()
+    pdb_file_paths = []
+    pdb_file_names = []
+
     mdtraj_topologies = []
 
+    # Packmol does not like long file paths, so we need to store just file names
+    # and do a temporary cd into the working directory to get around this.
     for index, molecule in enumerate(molecules):
 
-        tmp_filename = os.path.join(working_directory, f'{index}.pdb')
-        pdb_filenames.append(tmp_filename)
+        tmp_file_name = f'{index}.pdb'
+        tmp_file_path = os.path.join(working_directory, tmp_file_name)
 
-        mdtraj_topologies.append(_create_pdb_and_topology(molecule, tmp_filename))
+        pdb_file_paths.append(tmp_file_path)
+        pdb_file_names.append(tmp_file_name)
+
+        mdtraj_topologies.append(_create_pdb_and_topology(molecule, tmp_file_path))
+
+    structure_to_solvate_file_name = None
+
+    if structure_to_solvate is not None:
+
+        if not os.path.isfile(structure_to_solvate):
+            raise ValueError(f'The structure to solvate ({structure_to_solvate}) does not exist.')
+
+        structure_to_solvate_file_name = os.path.basename(structure_to_solvate)
+        shutil.copyfile(structure_to_solvate, os.path.join(working_directory, structure_to_solvate_file_name))
 
     # Run packmol
     if PACKMOL_PATH is None:
         raise IOError("Packmol not found, cannot run pack_box()")
 
-    output_filename = os.path.join(working_directory, "packmol_output.pdb")
+    output_file_name = "packmol_output.pdb"
+    output_file_path = os.path.join(working_directory, output_file_name)
 
     # Approximate volume to initialize box
     if box_size is None:
@@ -137,61 +157,61 @@ def pack_box(molecules,
 
     unitless_box_angstrom = box_size.value_in_unit(unit.angstrom)
 
-    packmol_input = _HEADER_TEMPLATE.format(tolerance, output_filename)
+    packmol_input = _HEADER_TEMPLATE.format(tolerance, output_file_name)
 
-    for (pdb_filename, molecule, count) in zip(pdb_filenames,
-                                               molecules,
-                                               number_of_copies):
+    for (pdb_file_name, molecule, count) in zip(pdb_file_names,
+                                                molecules,
+                                                number_of_copies):
 
-        packmol_input += _BOX_TEMPLATE.format(pdb_filename,
+        packmol_input += _BOX_TEMPLATE.format(pdb_file_name,
                                               count,
                                               unitless_box_angstrom,
                                               unitless_box_angstrom,
                                               unitless_box_angstrom)
 
-    if structure_to_solvate is not None:
+    if structure_to_solvate_file_name is not None:
 
-        if not os.path.isfile(structure_to_solvate):
-            raise ValueError(f'The structure to solvate ({structure_to_solvate}) does not exist.')
-
-        packmol_input += _SOLVATE_TEMPLATE.format(structure_to_solvate,
+        packmol_input += _SOLVATE_TEMPLATE.format(structure_to_solvate_file_name,
                                                   unitless_box_angstrom / 2.0,
                                                   unitless_box_angstrom / 2.0,
                                                   unitless_box_angstrom / 2.0)
 
     # Write packmol input
-    packmol_filename = os.path.join(working_directory, "packmol_input.txt")
+    packmol_file_name = "packmol_input.txt"
+    packmol_file_path = os.path.join(working_directory, packmol_file_name)
 
-    with open(packmol_filename, 'w') as file_handle:
+    with open(packmol_file_path, 'w') as file_handle:
         file_handle.write(packmol_input)
 
     packmol_succeeded = False
 
-    with open(packmol_filename) as file_handle:
+    with temporarily_change_directory(working_directory):
 
-        result = subprocess.check_output(PACKMOL_PATH,
-                                         stdin=file_handle,
-                                         stderr=subprocess.STDOUT).decode("utf-8")
+        with open(packmol_file_name) as file_handle:
 
-        if verbose:
-            logging.info(result)
+            result = subprocess.check_output(PACKMOL_PATH,
+                                             stdin=file_handle,
+                                             stderr=subprocess.STDOUT).decode("utf-8")
 
-        packmol_succeeded = result.find('Success!') > 0
+            if verbose:
+                logging.info(result)
+
+            packmol_succeeded = result.find('Success!') > 0
 
     if not retain_working_files:
 
-        os.unlink(packmol_filename)
+        os.unlink(packmol_file_path)
 
-        for filename in pdb_filenames:
-            os.unlink(filename)
+        for file_path in pdb_file_paths:
+            os.unlink(file_path)
 
     if not packmol_succeeded:
 
         if verbose:
             logging.info("Packmol failed to converge")
 
-        if os.path.isfile(output_filename):
-            os.unlink(output_filename)
+        if os.path.isfile(output_file_path):
+            os.unlink(output_file_path)
 
         if temporary_directory and not retain_working_files:
             shutil.rmtree(working_directory)
@@ -200,14 +220,14 @@ def pack_box(molecules,
 
     # Append missing connect statements to the end of the
     # output file.
-    positions, topology = _correct_packmol_output(output_filename,
+    positions, topology = _correct_packmol_output(output_file_path,
                                                   mdtraj_topologies,
                                                   number_of_copies,
                                                   structure_to_solvate)
 
     if not retain_working_files:
 
-        os.unlink(output_filename)
+        os.unlink(output_file_path)
 
         if temporary_directory:
             shutil.rmtree(working_directory)

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -12,12 +12,10 @@ import random
 import shutil
 import string
 import subprocess
-
-import numpy as np
-
 from distutils.spawn import find_executable
 from tempfile import mkdtemp
 
+import numpy as np
 from simtk import openmm
 from simtk import unit
 
@@ -214,7 +212,8 @@ def pack_box(molecules,
         if temporary_directory:
             shutil.rmtree(working_directory)
 
-    unitless_box_nm = box_size / unit.nanometers
+    # Add a 2 angstrom buffer to help alleviate PBC issues.
+    unitless_box_nm = (box_size + 2.0 * unit.angstrom).value_in_unit(unit.nanometers)
 
     box_vector_x = openmm.Vec3(unitless_box_nm, 0, 0)
     box_vector_y = openmm.Vec3(0, unitless_box_nm, 0)
@@ -270,9 +269,7 @@ def _approximate_volume_by_density(molecules,
 
         volume += molecule_volume * number
 
-    # Add 2 angs to help ease PBC issues.
-    box_edge = volume**(1.0/3.0) * box_scaleup_factor + 2.0 * unit.angstrom
-
+    box_edge = volume**(1.0/3.0) * box_scaleup_factor
     return box_edge
 
 

--- a/propertyestimator/utils/utils.py
+++ b/propertyestimator/utils/utils.py
@@ -134,17 +134,28 @@ def create_molecule_from_smiles(smiles, number_of_conformers=1):
     return molecule
 
 
-def setup_timestamp_logging():
-    """Set up timestamp-based logging."""
+def setup_timestamp_logging(file_path=None):
+    """Set up timestamp-based logging.
+
+    Parameters
+    ----------
+    file_path: str, optional
+        The file to write the log to. If none, the logger will
+        print to the terminal.
+    """
     formatter = logging.Formatter(fmt='%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s',
                                   datefmt='%H:%M:%S')
 
-    screen_handler = logging.StreamHandler(stream=sys.stdout)
-    screen_handler.setFormatter(formatter)
+    if file_path is None:
+        logger_handler = logging.StreamHandler(stream=sys.stdout)
+    else:
+        logger_handler = logging.FileHandler(file_path)
+
+    logger_handler.setFormatter(formatter)
 
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    logger.addHandler(screen_handler)
+    logger.addHandler(logger_handler)
 
 
 def get_nested_attribute(containing_object, name):

--- a/propertyestimator/utils/utils.py
+++ b/propertyestimator/utils/utils.py
@@ -2,6 +2,7 @@
 A collection of general utilities.
 """
 import abc
+import contextlib
 import copy
 import logging
 import os
@@ -286,6 +287,24 @@ def set_nested_attribute(containing_object, name, value):
                              'attribute.'.format(attribute_name))
 
         setattr(current_attribute, attribute_name, value)
+
+
+@contextlib.contextmanager
+def temporarily_change_directory(file_path):
+    """A context to temporarily change the working directory.
+
+    Parameters
+    ----------
+    file_path: str
+        The file path to temporarily change into.
+    """
+    prev_dir = os.getcwd()
+    os.chdir(os.path.abspath(file_path))
+
+    try:
+        yield
+    finally:
+        os.chdir(prev_dir)
 
 
 class SubhookedABCMeta(metaclass=abc.ABCMeta):

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -792,9 +792,10 @@ class Workflow:
 
             components.append(component_substance)
 
-        if (estimator_options.workflow_options is not None and
+        if estimator_options is None:
+            workflow_options = WorkflowOptions()
+        elif (estimator_options.workflow_options is not None and
             type(physical_property).__name__ in estimator_options.workflow_options):
-
             workflow_options = estimator_options.workflow_options[type(physical_property).__name__]
         else:
             workflow_options = WorkflowOptions()


### PR DESCRIPTION
## Description
A PR to implement direct host-guest binding affinity calculations into the estimator framework. The bulk of this PR has been to introduce two new protocols:

 - A `BaseYankProtocol` which handles the actual running of yank calculations, setting up base input `yaml` files and will allow easy integration of hydration / solvation free energy calculations
- A `LigandReceptorYankProtocol` which extends the base input `yaml` file creation to include specific options for ligand-receptor binding calculations.

This PR also fixes a number of the `packmol` utility bugs, as well as extends it to support solvation of structures.

This PR also comes with the usual plethora of bug fixes / QoL improvements

## Todos
  - [x] Test initial set up pipeline.

## Status
- [x] Ready to go