### PR TITLE
Fix RTD Builds

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -15,6 +15,8 @@ dependencies:
     # Standard dependencies
     - numpy
     - pandas
+    - lxml
+    - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
     - openmm
     - packmol
     - pymbar

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,6 @@ dependencies:
     - numpydoc
     - nbsphinx
     - m2r >=0.2.1
-    - sphinx_rtd_theme
 
     # Standard dependencies
     - numpy
@@ -22,3 +21,6 @@ dependencies:
     - dask
     - tornado <6
     - uncertainties
+
+    - pip:
+        - sphinx_rtd_theme

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,18 +11,16 @@ dependencies:
     - numpydoc
     - nbsphinx
     - m2r >=0.2.1
+    - sphinx_rtd_theme
 
     # Standard dependencies
     - numpy
     - pandas
     - lxml
-    - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
+    - icu 58*  # REQUIRED - DO NOT REMOVE.
     - openmm
     - packmol
     - pymbar
     - dask
     - tornado <6
     - uncertainties
-
-    - pip:
-        - sphinx_rtd_theme


### PR DESCRIPTION
## Description
Fixes the failing RTD builds by re-adding an `lxml` and a pinned `icu`  dependency.

## Status
- [x] Ready to go