### PR TITLE
Update Dependencies and Remove Travis Dependency Installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,6 @@ install:
 - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/test_env.yaml
 - conda activate test
 
-# Temporary addition until version 0.3.0 of the OFF toolkit is released.
-- conda config --add channels omnia --add channels conda-forge
-- conda install --yes --only-deps openforcefield
-- pip install git+https://github.com/openforcefield/openforcefield.git@master
-
-# Temporary addition until a version of yank which includes trailblaze checkpoints
-# is released
-- conda install --yes --only-deps yank
-- pip install git+https://github.com/choderalab/yank.git@trailblaze_checkpoint
-
 - python setup.py develop --no-deps
 script:
 - pytest -v --cov=propertyestimator propertyestimator/tests/

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,7 +17,7 @@ dependencies:
   - openeye-toolkits
 
     # Standard dependencies
-#  - openforcefield ==0.0.4
+  - openforcefield ==0.4.0
   - numpy
   - pandas
   - openmm
@@ -25,11 +25,11 @@ dependencies:
   - pymbar
   - mdtraj
   - dask
-  - distributed >=1.27.1
+  - distributed ==1.28.1
   - dask-jobqueue
   - tornado
   - coverage >=4.4
   - uncertainties
   - openmmtools
-#  - yank
+  - yank
   - pyyaml


### PR DESCRIPTION
## Description
Pins the version of dask distributed until [`dask-jobqueue` has been updated](https://github.com/dask/dask-jobqueue/issues/281), and moves the installation of the `openforcefield` and `yank` dependencies into the conda env file.

## Status
- [x] Ready to go