### PR TITLE
Quantities Serialization in Original Unit and More Compact Form

### DIFF
--- a/propertyestimator/utils/serialization.py
+++ b/propertyestimator/utils/serialization.py
@@ -9,6 +9,7 @@ import numpy as np
 from abc import ABC, abstractmethod
 from enum import Enum
 
+from openforcefield.utils import string_to_unit, unit_to_string
 from simtk import unit
 
 from propertyestimator.utils.quantities import EstimatedQuantity
@@ -40,78 +41,44 @@ def _type_string_to_object(type_string):
 
 
 def serialize_quantity(quantity):
-    """
-    Serialized a simtk.unit.Quantity into a dict of {'unitless_value': X, 'unit': Y}
-
-    .. todo:: Currently duplicates Jeff Wagners implementation.
+    """Serializes a simtk.unit.Quantity into a dictionary of the form
+    `{'value': quantity.value_in_unit(quantity.unit), 'unit': quantity.unit}`
 
     Parameters
     ----------
-    quantity : A simtk.unit.Quantity-wrapped value or iterator over values
-        The object to serialize
+    quantity : unit.Quantity
+        The quantity to serialize
 
     Returns
     -------
-    serialzied : dict
-        The serialized object
+    dict of str and str
+        A dictionary representation of a simtk.unit.Quantity
+        with keys of {"value", "unit"}
     """
 
-    if not isinstance(quantity, unit.Quantity):
-        raise ValueError('{} is not a Quantity'.format(type(quantity)))
-
-    serialized = dict()
-
-    # If it's None, just return None in all fields
-    if quantity is None:
-        serialized['unitless_value'] = None
-        serialized['unit'] = None
-        return serialized
-
-    # If it's not None, make sure it's a simtk.unit.Quantity
-    assert (hasattr(quantity, 'unit'))
-
-    quantity_unit = list()
-    for base_unit in quantity.unit.iter_all_base_units():
-        quantity_unit.append((base_unit[0].name, base_unit[1]))
-
-    conversion_factor = quantity.unit.get_conversion_factor_to_base_units()
-
-    unitless_value = (quantity / quantity.unit) * conversion_factor
-    serialized['unitless_value'] = unitless_value
-    serialized['unit'] = quantity_unit
-    return serialized
+    value = quantity.value_in_unit(quantity.unit)
+    return {'value': value, 'unit': unit_to_string(quantity.unit)}
 
 
 def deserialize_quantity(serialized):
-    """
-    Deserializes a simtk.unit.Quantity.
-
-    .. todo:: Currently duplicates Jeff Wagners implementation.
+    """Deserialize a simtk.unit.Quantity from a dictionary.
 
     Parameters
     ----------
-    serialized : dict
-        Serialized representation of a simtk.unit.Quantity. Must have keys ["unitless_value", "unit"]
+    serialized : dict of str and str
+        A dictionary representation of a simtk.unit.Quantity
+        which must have keys {"value", "unit"}
 
     Returns
     -------
     simtk.unit.Quantity
+        The deserialized quantity.
     """
 
     if '@type' in serialized:
         serialized.pop('@type')
 
-    if (serialized['unitless_value'] is None) and (serialized['unit'] is None):
-        return None
-    quantity_unit = None
-    for unit_name, power in serialized['unit']:
-        unit_name = unit_name.replace(' ', '_')  # Convert eg. 'elementary charge' to 'elementary_charge'
-        if quantity_unit is None:
-            quantity_unit = (getattr(unit, unit_name) ** power)
-        else:
-            quantity_unit *= (getattr(unit, unit_name) ** power)
-    quantity = unit.Quantity(serialized['unitless_value'], quantity_unit)
-    return quantity
+    return unit.Quantity(serialized['value'], string_to_unit(serialized['unit']))
 
 
 def deserialize_estimated_quantity(quantity_dictionary):


### PR DESCRIPTION
## Description
This PR uses the `openforcefield` toolkit utility methods to serialize quantities in their original units, and in a more compact form.

## Status
- [x] Ready to go