### PR TITLE
Quick Fix for Dask LSF Units Changes

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -26,7 +26,7 @@ dependencies:
   - mdtraj
   - dask
   - distributed ==1.28.1
-  - dask-jobqueue
+  - dask-jobqueue ==0.5.0
   - tornado
   - coverage >=4.4
   - uncertainties

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -273,6 +273,7 @@ class DaskLSFBackend(BaseDaskBackend):
         self._cluster = LSFCluster(queue=self._queue_name,
                                    cores=self._resources_per_worker.number_of_threads,
                                    walltime=self._resources_per_worker.wallclock_time_limit,
+                                   memory='1GB',  # Add a temporary value.
                                    mem=memory_bytes,
                                    job_extra=job_extra,
                                    env_extra=self._setup_script_commands,

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -260,7 +260,7 @@ class DaskLSFBackend(BaseDaskBackend):
         memory_bytes = requested_memory.value_in_unit(unit.byte)
 
         lsf_units = lsf_detect_units()
-        memory_string = lsf_format_bytes_ceil(memory_bytes, lsf_units=lsf_units)
+        memory_string = f'{lsf_format_bytes_ceil(memory_bytes, lsf_units=lsf_units)}{lsf_units.upper()}'
 
         job_extra = []
 

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -254,8 +254,13 @@ class DaskLSFBackend(BaseDaskBackend):
 
     def start(self):
 
+        from dask_jobqueue.lsf import lsf_detect_units, lsf_format_bytes_ceil
+
         requested_memory = self._resources_per_worker.per_thread_memory_limit
         memory_bytes = requested_memory.value_in_unit(unit.byte)
+
+        lsf_units = lsf_detect_units()
+        memory_string = lsf_format_bytes_ceil(memory_bytes, lsf_units=lsf_units)
 
         job_extra = []
 
@@ -273,7 +278,7 @@ class DaskLSFBackend(BaseDaskBackend):
         self._cluster = LSFCluster(queue=self._queue_name,
                                    cores=self._resources_per_worker.number_of_threads,
                                    walltime=self._resources_per_worker.wallclock_time_limit,
-                                   memory='1GB',  # Add a temporary value.
+                                   memory=memory_string,
                                    mem=memory_bytes,
                                    job_extra=job_extra,
                                    env_extra=self._setup_script_commands,


### PR DESCRIPTION
## Description
Implements a quick fix for the changed default LSF memory unit behaviour [introduced here](https://github.com/dask/dask-jobqueue/pull/274).

## Status
- [x] Ready to go