### PR TITLE
OMM State Reporter Quick Fix

### DIFF
--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -130,7 +130,7 @@ class StateReporter:
         state_xml = XmlSerializer.serialize(state)
 
         # Attempt to do a thread safe write.
-        _, file_path = tempfile.mkstemp(suffix='.xml')
+        file_path = self._file_path + '.tmp'
 
         with open(file_path, 'w') as file:
             file.write(state_xml)

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -3,7 +3,6 @@ A set of utilities for helping to perform simulations using openmm.
 """
 import logging
 import os
-import tempfile
 
 
 def setup_platform_with_resources(compute_resources, high_precision=False):


### PR DESCRIPTION
## Description
Fixes an issue where temporary checkpoint files could not be copied to the correct location:

```
[Errno 18] Invalid cross-device link: '/XXX/tmpiuxt4jti.xml' -> '/YYY/checkpoint.xml
```

## Status
- [x] Ready to go