### PR TITLE
Re-enable Support for Dask Nanny Process

### DIFF
--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -142,7 +142,7 @@ class DaskLSFBackend(BaseDaskBackend):
                  setup_script_commands=None,
                  extra_script_options=None,
                  adaptive_interval='10000ms',
-                 disable_nanny_process=True):
+                 disable_nanny_process=False):
 
         """Constructs a new DaskLocalClusterBackend
 

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -29,6 +29,10 @@ class Multiprocessor:
             return_value = func(*args, **kwargs)
             queue.put(return_value)
         except Exception as e:
+
+            formatted_exception = traceback.format_exception(None, e, e.__traceback__)
+            logging.info(formatted_exception)
+
             queue.put(e)
 
     @staticmethod

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -346,8 +346,6 @@ class DaskLSFBackend(BaseDaskBackend):
 
             logging.info(f'Launching a job with access to GPUs {available_resources._gpu_device_indices}')
 
-        logging.info(f'Available protocols: {available_protocols}')
-
         return_value = Multiprocessor.run(function, *args, **kwargs)
         return return_value
         # return function(*args, **kwargs)

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -29,11 +29,7 @@ class Multiprocessor:
             return_value = func(*args, **kwargs)
             queue.put(return_value)
         except Exception as e:
-
-            formatted_exception = traceback.format_exception(None, e, e.__traceback__)
-            logging.info(formatted_exception)
-
-            queue.put(e)
+            queue.put((e, e.__traceback__))
 
     @staticmethod
     def run(function, *args, **kwargs):
@@ -71,10 +67,10 @@ class Multiprocessor:
         return_value = queue.get()
         process.join()
 
-        if isinstance(return_value, Exception):
+        if isinstance(return_value, tuple) and len(return_value) > 0 and isinstance(return_value[0], Exception):
 
-            formatted_exception = traceback.format_exception(None, return_value, return_value.__traceback__)
-            logging.info(formatted_exception)
+            formatted_exception = traceback.format_exception(None, return_value[0], return_value[1])
+            logging.info(f'{formatted_exception} {return_value[0]} {return_value[1]}')
 
             raise return_value
 

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -14,7 +14,6 @@ from dask_jobqueue import LSFCluster
 from distributed import get_worker
 from simtk import unit
 
-from propertyestimator.workflow.plugins import available_protocols
 from .backends import PropertyEstimatorBackend, ComputeResources, QueueWorkerResources
 
 
@@ -299,6 +298,8 @@ class DaskLSFBackend(BaseDaskBackend):
     @staticmethod
     def _wrapped_function(function, *args, **kwargs):
 
+        from propertyestimator.workflow.plugins import available_protocols
+
         available_resources = kwargs['available_resources']
 
         protocols_to_import = kwargs.pop('available_protocols')
@@ -350,6 +351,8 @@ class DaskLSFBackend(BaseDaskBackend):
         # return function(*args, **kwargs)
 
     def submit_task(self, function, *args, **kwargs):
+
+        from propertyestimator.workflow.plugins import available_protocols
 
         key = kwargs.pop('key', None)
 

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -346,6 +346,8 @@ class DaskLSFBackend(BaseDaskBackend):
 
             logging.info(f'Launching a job with access to GPUs {available_resources._gpu_device_indices}')
 
+        logging.info(f'Available protocols: {available_protocols}')
+
         return_value = Multiprocessor.run(function, *args, **kwargs)
         return return_value
         # return function(*args, **kwargs)

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -6,6 +6,7 @@ import logging
 import multiprocessing
 import os
 import shutil
+import traceback
 
 import dask
 from dask import distributed
@@ -67,6 +68,10 @@ class Multiprocessor:
         process.join()
 
         if isinstance(return_value, Exception):
+
+            formatted_exception = traceback.format_exception(None, return_value, return_value.__traceback__)
+            logging.info(formatted_exception)
+
             raise return_value
 
         return return_value

--- a/propertyestimator/tests/test_backends/test_dask.py
+++ b/propertyestimator/tests/test_backends/test_dask.py
@@ -1,7 +1,7 @@
 import pytest
 
 from propertyestimator.backends import DaskLSFBackend, QueueWorkerResources
-from propertyestimator.backends.dask import Multiprocessor
+from propertyestimator.backends.dask import _Multiprocessor
 from propertyestimator.workflow.plugins import available_protocols
 
 
@@ -37,7 +37,7 @@ def test_multiprocessor():
 
     expected_output = 12345
 
-    return_value = Multiprocessor.run(dummy_function, expected_output)
+    return_value = _Multiprocessor.run(dummy_function, expected_output)
     assert expected_output == return_value
 
 

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -1277,7 +1277,6 @@ class WorkflowGraph:
         """
 
         from propertyestimator.workflow.plugins import available_protocols
-        logging.info(f'Available protocols: {available_protocols}')
 
         # The path where the output of this protocol will be stored.
         output_dictionary_path = path.join(directory, '{}_output.json'.format(protocol_schema.id))

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -1274,6 +1274,7 @@ class WorkflowGraph:
 
         # The path where the output of this protocol will be stored.
         output_dictionary_path = path.join(directory, '{}_output.json'.format(protocol_schema.id))
+        os.makedirs(directory, exist_ok=True)
 
         # We need to make sure ALL exceptions are handled within this method,
         # or any function which will be executed on a calculation backend to
@@ -1326,8 +1327,6 @@ class WorkflowGraph:
             # and awkward args and kwargs syntax.
             protocol = available_protocols[protocol_schema.type](protocol_schema.id)
             protocol.schema = protocol_schema
-
-            os.makedirs(directory, exist_ok=True)
 
             # Pass the outputs of previously executed protocols as input to the
             # protocol to execute.

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -23,7 +23,6 @@ from propertyestimator.utils.exceptions import PropertyEstimatorException
 from propertyestimator.utils.serialization import TypedBaseModel, TypedJSONEncoder, TypedJSONDecoder
 from propertyestimator.utils.string import extract_variable_index_and_name
 from propertyestimator.utils.utils import SubhookedABCMeta, get_nested_attribute
-from propertyestimator.workflow.plugins import available_protocols
 from propertyestimator.workflow.protocols import BaseProtocol
 from propertyestimator.workflow.schemas import WorkflowSchema, ProtocolReplicator, WorkflowSimulationDataToStore, \
     WorkflowDataCollectionToStore
@@ -247,6 +246,7 @@ class Workflow:
         schema: WorkflowSchema
             The schema to use when creating the protocols
         """
+        from propertyestimator.workflow.plugins import available_protocols
 
         self._apply_replicators(schema)
 
@@ -558,6 +558,8 @@ class Workflow:
             A list of the values which will be inserted
             into the newly replicated protocols.
         """
+        from propertyestimator.workflow.plugins import available_protocols
+
         schema_to_replicate = schema.protocols[protocol_path.start_protocol]
         replacement_string = '$({})'.format(replicator.id)
 
@@ -638,6 +640,8 @@ class Workflow:
         template_values: :obj:`list` of :obj:`Any`
             The list of values that the protocols were replicated for.
         """
+        from propertyestimator.workflow.plugins import available_protocols
+
         replacement_string = '$({})'.format(replicator.id)
 
         for protocol_id in schema.protocols:
@@ -1271,6 +1275,9 @@ class WorkflowGraph:
         dict of str and Any
             A dictionary which contains the outputs of the executed protocol.
         """
+
+        from propertyestimator.workflow.plugins import available_protocols
+        logging.info(f'Available protocols: {available_protocols}')
 
         # The path where the output of this protocol will be stored.
         output_dictionary_path = path.join(directory, '{}_output.json'.format(protocol_schema.id))

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -6,6 +6,7 @@ import copy
 import json
 import logging
 import math
+import os
 import re
 import time
 import traceback
@@ -1326,8 +1327,7 @@ class WorkflowGraph:
             protocol = available_protocols[protocol_schema.type](protocol_schema.id)
             protocol.schema = protocol_schema
 
-            if not path.isdir(directory):
-                makedirs(directory)
+            os.makedirs(directory, exist_ok=True)
 
             # Pass the outputs of previously executed protocols as input to the
             # protocol to execute.


### PR DESCRIPTION
## Description
This PR aims to re-enable the use of dask nanny processes for extra stability. 

This was previously disabled due to the necessity of running each individual _task_ within a separate process, which could not be within the nanny process when it was run as a daemon. Now dask has exposed control over [whether the process is a daemon or not](https://github.com/dask/distributed/issues/2718) it is possible to re-enable the nanny process.

## Status
- [x] Ready to go