### PR TITLE
Increased the Default Simulation Timestep

### DIFF
--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -607,8 +607,8 @@ class EnthalpyOfVaporization(PhysicalProperty):
         gas_protocols.equilibration_simulation.enable_pbc = False
 
         gas_protocols.production_simulation.ensemble = Ensemble.NVT
-        gas_protocols.production_simulation.steps = 10000000
-        gas_protocols.production_simulation.output_frequency = 50000
+        gas_protocols.production_simulation.steps = 5000000
+        gas_protocols.production_simulation.output_frequency = 25000
         gas_protocols.production_simulation.enable_pbc = False
 
         # Combine the values to estimate the final energy of vaporization

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -197,7 +197,7 @@ class RunOpenMMSimulation(BaseProtocol):
         self._steps = 1000
 
         self._thermostat_friction = 1.0 / unit.picoseconds
-        self._timestep = 0.001 * unit.picoseconds
+        self._timestep = 0.002 * unit.picoseconds
 
         self._output_frequency = 500000
 
@@ -477,7 +477,7 @@ class BaseYankProtocol(BaseProtocol):
         super().__init__(protocol_id)
 
         self._thermodynamic_state = None
-        self._timestep = 1 * unit.femtosecond
+        self._timestep = 2 * unit.femtosecond
 
         self._number_of_iterations = 1
 

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -4,6 +4,8 @@ A set of utilities for setting up property estimation workflows.
 import copy
 from collections import namedtuple
 
+from simtk import unit
+
 from propertyestimator.protocols import analysis, forcefield, gradients, groups, reweighting, coordinates, simulation
 from propertyestimator.thermodynamics import Ensemble
 from propertyestimator.workflow import WorkflowOptions
@@ -188,12 +190,12 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
         3) Perform an energy minimisation on the system.
 
         4) Run a short NPT equilibration simulation for 100000 steps
-           using a timestep of 1fs.
+           using a timestep of 2fs.
 
         5) Within a conditional group (up to a maximum of 100 times):
 
             5a) Run a longer NPT production simulation for 1000000 steps
-           using a timestep of 1fs
+           using a timestep of 2fs
 
             5b) Extract the average value of an observable and
                 it's uncertainty.
@@ -255,6 +257,7 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
     equilibration_simulation.ensemble = Ensemble.NPT
     equilibration_simulation.steps = 100000
     equilibration_simulation.output_frequency = 5000
+    equilibration_simulation.timestep = 2.0 * unit.femtosecond
     equilibration_simulation.thermodynamic_state = ProtocolPath('thermodynamic_state', 'global')
     equilibration_simulation.input_coordinate_file = ProtocolPath('output_coordinate_file', energy_minimisation.id)
     equilibration_simulation.system_path = ProtocolPath('system_path', assign_parameters.id)
@@ -264,6 +267,7 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
     production_simulation.ensemble = Ensemble.NPT
     production_simulation.steps = 1000000
     production_simulation.output_frequency = 10000
+    production_simulation.timestep = 2.0 * unit.femtosecond
     production_simulation.thermodynamic_state = ProtocolPath('thermodynamic_state', 'global')
     production_simulation.input_coordinate_file = ProtocolPath('output_coordinate_file', equilibration_simulation.id)
     production_simulation.system_path = ProtocolPath('system_path', assign_parameters.id)


### PR DESCRIPTION
## Description
This PR increases the default simulation timestep to 2fs now that the [latest SMIRNOFF force field includes h-bond constraints](https://github.com/openforcefield/smirnoff99Frosst/pull/99) by default.

## Status
- [x] Ready to go