### PR TITLE
Switch to Pint Units

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -22,6 +22,7 @@ dependencies:
   - numpy
   - pandas
   - openmm
+  - pint
   - packmol
   - pymbar
   - mdtraj

--- a/propertyestimator/__init__.py
+++ b/propertyestimator/__init__.py
@@ -7,6 +7,7 @@ Property calculation toolkit from the Open Forcefield Consortium.
 # Safe to remove with Python 3-only code
 from __future__ import absolute_import
 
+import os
 import pkg_resources
 
 from ._version import get_versions
@@ -26,9 +27,7 @@ for entry_point in pkg_resources.iter_entry_points('propertyestimator.plugins'):
 
 # Set up pint.
 from pint import UnitRegistry
-
 unit = UnitRegistry()
-unit.define("dalton = gram / mole = u = amu = Da")
 
 # Handle versioneer
 versions = get_versions()

--- a/propertyestimator/__init__.py
+++ b/propertyestimator/__init__.py
@@ -24,6 +24,12 @@ for entry_point in pkg_resources.iter_entry_points('propertyestimator.plugins'):
         formatted_exception = traceback.format_exception(None, e, e.__traceback__)
         logging.warning(f'Could not load the {entry_point} plugin: {formatted_exception}')
 
+# Set up pint.
+from pint import UnitRegistry
+
+unit = UnitRegistry()
+unit.define("dalton = gram / mole = u = amu = Da")
+
 # Handle versioneer
 versions = get_versions()
 __version__ = versions['version']

--- a/propertyestimator/backends/backends.py
+++ b/propertyestimator/backends/backends.py
@@ -4,7 +4,7 @@ Defines the base API for the property estimator task calculation backend.
 import re
 from enum import Enum
 
-from propertyestimator import unit as unit
+from propertyestimator import unit
 
 
 class ComputeResources:

--- a/propertyestimator/backends/backends.py
+++ b/propertyestimator/backends/backends.py
@@ -4,7 +4,7 @@ Defines the base API for the property estimator task calculation backend.
 import re
 from enum import Enum
 
-from simtk import unit
+from propertyestimator import unit as unit
 
 
 class ComputeResources:
@@ -50,9 +50,10 @@ class ComputeResources:
         self._number_of_gpus = number_of_gpus
 
         self._preferred_gpu_toolkit = preferred_gpu_toolkit
-        self._gpu_device_indices = None  # A workaround for when using a local cluster
-                                         # backend which is strictly for internal purposes
-                                         # only for now.
+        # A workaround for when using a local cluster
+        # backend which is strictly for internal purposes
+        # only for now.
+        self._gpu_device_indices = None
         
         assert self._number_of_threads >= 0
         assert self._number_of_gpus >= 0
@@ -108,7 +109,7 @@ class QueueWorkerResources(ComputeResources):
         return self._wallclock_time_limit
 
     def __init__(self, number_of_threads=1, number_of_gpus=0, preferred_gpu_toolkit=None,
-                 per_thread_memory_limit=1*(unit.giga*unit.bytes), wallclock_time_limit="01:00"):
+                 per_thread_memory_limit=1*unit.gigabytes, wallclock_time_limit="01:00"):
         """Constructs a new ComputeResources object.
 
         Notes
@@ -136,7 +137,7 @@ class QueueWorkerResources(ComputeResources):
         assert self._per_thread_memory_limit is not None
 
         assert (isinstance(self._per_thread_memory_limit, unit.Quantity) and
-                self._per_thread_memory_limit.unit.is_compatible(unit.byte))
+                unit.get_base_units(unit.byte)[-1] == unit.get_base_units(self._per_thread_memory_limit.units)[-1])
 
         assert self._per_thread_memory_limit > 0 * unit.byte
 

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -510,7 +510,7 @@ class DaskLocalCluster(BaseDaskBackend):
 
         if self._resources_per_worker.number_of_gpus > 0:
 
-            for index, worker in enumerate(self._cluster.workers):
+            for index, worker in self._cluster.workers.items():
                 self._gpu_device_indices_by_worker[worker.id] = str(index)
 
         super(DaskLocalCluster, self).start()

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -12,7 +12,7 @@ import dask
 from dask import distributed
 from dask_jobqueue import LSFCluster
 from distributed import get_worker
-from simtk import unit
+from propertyestimator import unit
 
 from .backends import PropertyEstimatorBackend, ComputeResources, QueueWorkerResources
 
@@ -263,7 +263,6 @@ class DaskLSFBackend(BaseDaskBackend):
         >>> # Create the backend which will adaptively try to spin up between one and
         >>> # ten workers with the requested resources depending on the calculation load.
         >>> from propertyestimator.backends import DaskLSFBackend
-        >>> from simtk.unit import unit
         >>>
         >>> lsf_backend = DaskLSFBackend(minimum_number_of_workers=1,
         >>>                              maximum_number_of_workers=10,
@@ -314,7 +313,7 @@ class DaskLSFBackend(BaseDaskBackend):
         from dask_jobqueue.lsf import lsf_detect_units, lsf_format_bytes_ceil
 
         requested_memory = self._resources_per_worker.per_thread_memory_limit
-        memory_bytes = requested_memory.value_in_unit(unit.byte)
+        memory_bytes = requested_memory.to(unit.byte).magnitude
 
         lsf_units = lsf_detect_units()
         memory_string = f'{lsf_format_bytes_ceil(memory_bytes, lsf_units=lsf_units)}{lsf_units.upper()}'

--- a/propertyestimator/datasets/datasets.py
+++ b/propertyestimator/datasets/datasets.py
@@ -170,7 +170,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         >>> from propertyestimator.datasets import ThermoMLDataSet
         >>> data_set = ThermoMLDataSet.from_doi('10.1016/j.jct.2016.10.001')
         >>>
-        >>> from simtk import unit
+        >>> from propertyestimator import unit
         >>> data_set.filter_by_temperature(min_temperature=130*unit.kelvin, max_temperature=260*unit.kelvin)
         """
 
@@ -197,7 +197,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         >>> from propertyestimator.datasets import ThermoMLDataSet
         >>> data_set = ThermoMLDataSet.from_doi('10.1016/j.jct.2016.10.001')
         >>>
-        >>> from simtk import unit
+        >>> from propertyestimator import unit
         >>> data_set.filter_by_temperature(min_pressure=70*unit.kilopascal, max_temperature=150*unit.kilopascal)
         """
         def filter_function(x):

--- a/propertyestimator/properties/dielectric.py
+++ b/propertyestimator/properties/dielectric.py
@@ -5,6 +5,9 @@ A collection of dielectric physical property definitions.
 import logging
 
 import numpy as np
+from simtk import openmm
+
+from propertyestimator import unit
 from propertyestimator.datasets.plugins import register_thermoml_property
 from propertyestimator.properties import PhysicalProperty, PropertyPhase
 from propertyestimator.properties.plugins import register_estimable_property
@@ -21,7 +24,6 @@ from propertyestimator.workflow import plugins
 from propertyestimator.workflow.decorators import protocol_input, protocol_output
 from propertyestimator.workflow.schemas import WorkflowSchema
 from propertyestimator.workflow.utils import ProtocolPath
-from simtk import openmm, unit
 
 
 @plugins.register_calculation_protocol()
@@ -41,7 +43,7 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
 
     @protocol_output(unit.Quantity)
     def uncorrelated_volumes(self):
-        """The uncorrelated volumes which were used in the dielect
+        """The uncorrelated volumes which were used in the dielectric
         calculation."""
         pass
 
@@ -98,7 +100,7 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
         e0 = 8.854187817E-12 * unit.farad / unit.meter  # Taken from QCElemental
 
         dielectric_constant = 1.0 + dipole_variance / (3 *
-                                                       unit.BOLTZMANN_CONSTANT_kB *
+                                                       unit.boltzmann_constant *
                                                        temperature *
                                                        volume *
                                                        e0)
@@ -108,6 +110,8 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
     def execute(self, directory, available_resources):
 
         import mdtraj
+        from simtk import unit as simtk_unit
+        from simtk.openmm import XmlSerializer
 
         logging.info('Extracting dielectrics: ' + self.id)
 
@@ -117,8 +121,6 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
             return base_exception
 
         charge_list = []
-
-        from simtk.openmm import XmlSerializer
 
         with open(self._system_path, 'rb') as file:
             self._system = XmlSerializer.deserialize(file.read().decode())
@@ -133,7 +135,7 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
             for atom_index in range(force.getNumParticles()):
 
                 charge = force.getParticleParameters(atom_index)[0]
-                charge /= unit.elementary_charge
+                charge = charge.value_in_unit(simtk_unit.elementary_charge)
 
                 charge_list.append(charge)
 
@@ -149,7 +151,7 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
 
         volumes = self.trajectory[sample_indices].unitcell_volumes
 
-        self._uncorrelated_values = unit.Quantity(dipole_moments, None)
+        self._uncorrelated_values = dipole_moments * unit.dimensionless
         self._uncorrelated_volumes = volumes * unit.nanometer ** 3
 
         value, uncertainty = bootstrap(self._bootstrap_function,
@@ -158,8 +160,8 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
                                        dipoles=dipole_moments,
                                        volumes=volumes)
 
-        self._value = EstimatedQuantity(unit.Quantity(value, None),
-                                        unit.Quantity(uncertainty, None), self.id)
+        self._value = EstimatedQuantity(value * unit.dimensionless,
+                                        uncertainty * unit.dimensionless, self.id)
 
         logging.info('Extracted dielectrics: ' + self.id)
 
@@ -218,7 +220,7 @@ class ReweightDielectricConstant(reweighting.ReweightWithMBARProtocol):
         e0 = 8.854187817E-12 * unit.farad / unit.meter  # Taken from QCElemental
 
         dielectric_constant = 1.0 + dipole_variance / (3 *
-                                                       unit.BOLTZMANN_CONSTANT_kB *
+                                                       unit.boltzmann_constant *
                                                        self._thermodynamic_state.temperature *
                                                        volume *
                                                        e0)

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -4,8 +4,7 @@ A collection of enthalpy physical property definitions.
 
 from collections import namedtuple
 
-from simtk import unit
-
+from propertyestimator import unit
 from propertyestimator.datasets.plugins import register_thermoml_property
 from propertyestimator.properties.plugins import register_estimable_property
 from propertyestimator.properties.properties import PhysicalProperty, PropertyPhase
@@ -617,7 +616,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
         energy_of_vaporization.value_a = ProtocolPath('value', extract_liquid_energy.id)
 
         ideal_volume = miscellaneous.MultiplyValue('ideal_volume')
-        ideal_volume.value = EstimatedQuantity(unit.constants.MOLAR_GAS_CONSTANT_R,
+        ideal_volume.value = EstimatedQuantity(1.0 * unit.molar_gas_constant,
                                                0.0 * unit.joule / unit.mole / unit.kelvin,
                                                'Universal Constant')
         ideal_volume.multiplier = ProtocolPath('thermodynamic_state.temperature', 'global')
@@ -791,7 +790,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
         energy_of_vaporization.value_a = ProtocolPath('value', liquid_protocols.mbar_protocol.id)
 
         ideal_volume = miscellaneous.MultiplyValue('ideal_volume')
-        ideal_volume.value = EstimatedQuantity(unit.constants.MOLAR_GAS_CONSTANT_R,
+        ideal_volume.value = EstimatedQuantity(1.0 * unit.molar_gas_constant,
                                                0.0 * unit.joule / unit.mole / unit.kelvin,
                                                'Universal Constant')
         ideal_volume.multiplier = ProtocolPath('thermodynamic_state.temperature', 'global')

--- a/propertyestimator/properties/properties.py
+++ b/propertyestimator/properties/properties.py
@@ -306,12 +306,12 @@ class PhysicalProperty(TypedBaseModel):
 
     @property
     def temperature(self):
-        """simtk.unit.Quantity or None: The temperature at which the property was collected."""
+        """propertyestimator.unit.Quantity or None: The temperature at which the property was collected."""
         return None if self.thermodynamic_state is None else self.thermodynamic_state.temperature
 
     @property
     def pressure(self):
-        """simtk.unit.Quantity or None: The pressure at which the property was collected."""
+        """propertyestimator.unit.Quantity or None: The pressure at which the property was collected."""
         return None if self.thermodynamic_state is None else self.thermodynamic_state.pressure
 
     @property
@@ -332,9 +332,9 @@ class PhysicalProperty(TypedBaseModel):
 
         Parameters
         ----------
-        value : simtk.unit.Quantity
+        value : propertyestimator.unit.Quantity
             The value of the property.
-        uncertainty : simtk.unit.Quantity
+        uncertainty : propertyestimator.unit.Quantity
             The uncertainty in the properties value.
         """
         self.value = value

--- a/propertyestimator/protocols/forcefield.py
+++ b/propertyestimator/protocols/forcefield.py
@@ -7,7 +7,6 @@ from enum import Enum
 from os import path
 
 import numpy as np
-from simtk import unit
 from simtk.openmm import app
 
 from propertyestimator.substances import Substance
@@ -119,21 +118,22 @@ class BuildSmirnoffSystem(BaseProtocol):
             The molecules with assigned charges.
         """
         from openforcefield.topology import Molecule
+        from simtk import unit as simtk_unit
 
         sodium = Molecule.from_smiles('[Na+]')
-        sodium.partial_charges = np.array([1.0]) * unit.elementary_charge
+        sodium.partial_charges = np.array([1.0]) * simtk_unit.elementary_charge
 
         potassium = Molecule.from_smiles('[K+]')
-        potassium.partial_charges = np.array([1.0]) * unit.elementary_charge
+        potassium.partial_charges = np.array([1.0]) * simtk_unit.elementary_charge
 
         calcium = Molecule.from_smiles('[Ca+2]')
-        calcium.partial_charges = np.array([2.0]) * unit.elementary_charge
+        calcium.partial_charges = np.array([2.0]) * simtk_unit.elementary_charge
 
         chlorine = Molecule.from_smiles('[Cl-]')
-        chlorine.partial_charges = np.array([-1.0]) * unit.elementary_charge
+        chlorine.partial_charges = np.array([-1.0]) * simtk_unit.elementary_charge
 
         water = Molecule.from_smiles('O')
-        water.partial_charges = np.array([-0.834, 0.417, 0.417]) * unit.elementary_charge
+        water.partial_charges = np.array([-0.834, 0.417, 0.417]) * simtk_unit.elementary_charge
 
         return [sodium, potassium, calcium, chlorine, water]
 

--- a/propertyestimator/protocols/groups.py
+++ b/propertyestimator/protocols/groups.py
@@ -13,13 +13,12 @@ import logging
 from enum import Enum, unique
 from os import path, makedirs
 
+from propertyestimator import unit
 from propertyestimator.utils import graph
 from propertyestimator.utils.exceptions import PropertyEstimatorException
 from propertyestimator.workflow import plugins
 from propertyestimator.workflow.decorators import MergeBehaviour, protocol_input
 from propertyestimator.workflow.plugins import register_calculation_protocol, available_protocols
-from simtk import unit
-
 from propertyestimator.workflow.protocols import BaseProtocol, ProtocolPath
 from propertyestimator.workflow.schemas import ProtocolGroupSchema
 
@@ -781,7 +780,7 @@ class ConditionalGroup(ProtocolGroup):
         right_hand_value_correct_units = right_hand_value
 
         if isinstance(right_hand_value, unit.Quantity) and isinstance(left_hand_value, unit.Quantity):
-            right_hand_value_correct_units = right_hand_value.in_units_of(left_hand_value.unit)
+            right_hand_value_correct_units = right_hand_value.to(left_hand_value.units)
 
         logging.info(f'Evaluating condition for protocol {self.id}: '
                      f'{left_hand_value} {condition.type} {right_hand_value_correct_units}')

--- a/propertyestimator/protocols/miscellaneous.py
+++ b/propertyestimator/protocols/miscellaneous.py
@@ -2,8 +2,8 @@
 A collection of protocols for running analysing the results of molecular simulations.
 """
 import numpy as np
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.substances import Substance
 from propertyestimator.utils.exceptions import PropertyEstimatorException
 from propertyestimator.utils.quantities import EstimatedQuantity

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -10,12 +10,14 @@ from enum import Enum
 
 import numpy as np
 import yaml
-from simtk import unit, openmm
+from simtk import openmm, unit as simtk_unit
 from simtk.openmm import app
 
+from propertyestimator import unit
 from propertyestimator.thermodynamics import ThermodynamicState, Ensemble
 from propertyestimator.utils.exceptions import PropertyEstimatorException
-from propertyestimator.utils.openmm import setup_platform_with_resources
+from propertyestimator.utils.openmm import setup_platform_with_resources, openmm_quantity_to_pint,\
+    pint_quantity_to_openmm
 from propertyestimator.utils.quantities import EstimatedQuantity
 from propertyestimator.utils.statistics import StatisticsArray, ObservableType
 from propertyestimator.utils.utils import temporarily_change_directory, safe_unlink
@@ -72,7 +74,7 @@ class RunEnergyMinimisation(BaseProtocol):
 
         self._enable_pbc = True
 
-        self._tolerance = 10*unit.kilojoules_per_mole
+        self._tolerance = 10*unit.kilojoules / unit.mole
         self._max_iterations = 0
 
         self._output_coordinate_file = None
@@ -100,7 +102,7 @@ class RunEnergyMinimisation(BaseProtocol):
                 force.setNonbondedMethod(0)  # NoCutoff = 0, NonbondedMethod.CutoffNonPeriodic = 1
 
         # TODO: Expose the constraint tolerance
-        integrator = openmm.VerletIntegrator(0.002 * unit.picoseconds)
+        integrator = openmm.VerletIntegrator(0.002 * simtk_unit.picoseconds)
         simulation = app.Simulation(input_pdb_file.topology, self._system, integrator, platform)
 
         box_vectors = input_pdb_file.topology.getPeriodicBoxVectors()
@@ -111,7 +113,7 @@ class RunEnergyMinimisation(BaseProtocol):
         simulation.context.setPeriodicBoxVectors(*box_vectors)
         simulation.context.setPositions(input_pdb_file.positions)
 
-        simulation.minimizeEnergy(self._tolerance, self._max_iterations)
+        simulation.minimizeEnergy(pint_quantity_to_openmm(self._tolerance), self._max_iterations)
 
         positions = simulation.context.getState(getPositions=True).getPositions()
 
@@ -227,8 +229,10 @@ class RunOpenMMSimulation(BaseProtocol):
 
     def execute(self, directory, available_resources):
 
-        temperature = self._thermodynamic_state.temperature
-        pressure = None if self._ensemble == Ensemble.NVT else self._thermodynamic_state.pressure
+        # We handle most things in OMM units here.
+        temperature = pint_quantity_to_openmm(self._thermodynamic_state.temperature)
+        pressure = pint_quantity_to_openmm(None if self._ensemble == Ensemble.NVT else
+                                           self._thermodynamic_state.pressure)
 
         if temperature is None:
 
@@ -328,9 +332,12 @@ class RunOpenMMSimulation(BaseProtocol):
         system = openmm_state.get_system(remove_thermostat=True)
 
         # Set up the integrator.
+        thermostat_friction = pint_quantity_to_openmm(self._thermostat_friction)
+        timestep = pint_quantity_to_openmm(self._timestep)
+
         integrator = openmmtools.integrators.LangevinIntegrator(temperature=temperature,
-                                                                collision_rate=self._thermostat_friction,
-                                                                timestep=self._timestep)
+                                                                collision_rate=thermostat_friction,
+                                                                timestep=timestep)
 
         # Create the simulation context.
         context = openmm.Context(system, integrator, platform)
@@ -394,33 +401,36 @@ class RunOpenMMSimulation(BaseProtocol):
         StatisticsArray
             The statistics array with statistics appended.
         """
-        beta = 1.0 / (unit.BOLTZMANN_CONSTANT_kB * temperature)
+        temperature = openmm_quantity_to_pint(temperature)
+        pressure = openmm_quantity_to_pint(pressure)
 
-        potential_energies = np.array(raw_statistics[ObservableType.PotentialEnergy]) * unit.kilojoule_per_mole
-        kinetic_energies = np.array(raw_statistics[ObservableType.KineticEnergy]) * unit.kilojoule_per_mole
+        beta = 1.0 / (unit.boltzmann_constant * temperature)
+
+        potential_energies = np.array(raw_statistics[ObservableType.PotentialEnergy]) * unit.kilojoules / unit.mole
+        kinetic_energies = np.array(raw_statistics[ObservableType.KineticEnergy]) * unit.kilojoules / unit.mole
         volumes = np.array(raw_statistics[ObservableType.Volume]) * unit.angstrom ** 3
 
         # Calculate the instantaneous temperature, taking account the
         # systems degrees of freedom.
-        temperatures = 2.0 * kinetic_energies / (degrees_of_freedom * unit.MOLAR_GAS_CONSTANT_R)
+        temperatures = 2.0 * kinetic_energies / (degrees_of_freedom * unit.molar_gas_constant)
 
         # Calculate the systems enthalpy and reduced potential.
         total_energies = potential_energies + kinetic_energies
         enthalpies = None
 
-        reduced_potentials = potential_energies / unit.AVOGADRO_CONSTANT_NA
+        reduced_potentials = potential_energies / unit.avogadro_number
 
         if pressure is not None:
 
             pv_terms = pressure * volumes
 
             reduced_potentials += pv_terms
-            enthalpies = total_energies + pv_terms * unit.AVOGADRO_CONSTANT_NA
+            enthalpies = total_energies + pv_terms * unit.avogadro_number
 
         reduced_potentials = (beta * reduced_potentials) * unit.dimensionless
 
         # Calculate the systems density.
-        densities = total_mass / (volumes * unit.AVOGADRO_CONSTANT_NA)
+        densities = total_mass / (volumes * unit.avogadro_number)
 
         statistics_array = StatisticsArray()
 
@@ -484,17 +494,19 @@ class RunOpenMMSimulation(BaseProtocol):
         system = context.getSystem()
 
         degrees_of_freedom = sum([3 for i in range(system.getNumParticles()) if
-                                  system.getParticleMass(i) > 0 * unit.dalton])
+                                  system.getParticleMass(i) > 0 * simtk_unit.dalton])
 
         degrees_of_freedom -= system.getNumConstraints()
 
         if any(type(system.getForce(i)) == openmm.CMMotionRemover for i in range(system.getNumForces())):
             degrees_of_freedom -= 3
 
-        total_mass = 0.0 * unit.dalton
+        total_mass = 0.0 * simtk_unit.dalton
 
         for i in range(system.getNumParticles()):
             total_mass += system.getParticleMass(i)
+
+        total_mass = openmm_quantity_to_pint(total_mass)
 
         # Perform the simulation.
         current_step_count = 0
@@ -520,11 +532,11 @@ class RunOpenMMSimulation(BaseProtocol):
 
                 # Write out the energies and system statistics.
                 raw_statistics[ObservableType.PotentialEnergy].append(state.getPotentialEnergy().
-                                                                      value_in_unit(unit.kilojoule_per_mole))
+                                                                      value_in_unit(simtk_unit.kilojoules_per_mole))
                 raw_statistics[ObservableType.KineticEnergy].append(state.getKineticEnergy().
-                                                                    value_in_unit(unit.kilojoule_per_mole))
+                                                                    value_in_unit(simtk_unit.kilojoules_per_mole))
                 raw_statistics[ObservableType.Volume].append(state.getPeriodicBoxVolume().
-                                                             value_in_unit(unit.angstrom ** 3))
+                                                             value_in_unit(simtk_unit.angstrom ** 3))
 
                 self._write_statistics_array(raw_statistics, temperature, pressure,
                                              degrees_of_freedom, total_mass)
@@ -693,8 +705,8 @@ class BaseYankProtocol(BaseProtocol):
             'verbose': self._verbose,
             'output_dir': '.',
 
-            'temperature': quantity_to_string(self._thermodynamic_state.temperature),
-            'pressure': quantity_to_string(self._thermodynamic_state.pressure),
+            'temperature': quantity_to_string(pint_quantity_to_openmm(self._thermodynamic_state.temperature)),
+            'pressure': quantity_to_string(pint_quantity_to_openmm(self._thermodynamic_state.pressure)),
 
             'minimize': True,
 
@@ -702,7 +714,7 @@ class BaseYankProtocol(BaseProtocol):
             'default_nsteps_per_iteration': self._steps_per_iteration,
             'checkpoint_interval': self._checkpoint_interval,
 
-            'default_timestep': quantity_to_string(self._timestep),
+            'default_timestep': quantity_to_string(pint_quantity_to_openmm(self._timestep)),
 
             'annihilate_electrostatics': True,
             'annihilate_sterics': False,
@@ -932,8 +944,8 @@ class BaseYankProtocol(BaseProtocol):
             if error is not None:
                 return PropertyEstimatorException(directory, error)
 
-        self._estimated_free_energy = EstimatedQuantity(free_energy,
-                                                        free_energy_uncertainty,
+        self._estimated_free_energy = EstimatedQuantity(openmm_quantity_to_pint(free_energy),
+                                                        openmm_quantity_to_pint(free_energy_uncertainty),
                                                         self._id)
 
         return self._get_output_dictionary()

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -4,8 +4,7 @@ A set of utilities for setting up property estimation workflows.
 import copy
 from collections import namedtuple
 
-from simtk import unit
-
+from propertyestimator import unit
 from propertyestimator.protocols import analysis, forcefield, gradients, groups, reweighting, coordinates, simulation
 from propertyestimator.thermodynamics import Ensemble
 from propertyestimator.workflow import WorkflowOptions

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -7,8 +7,8 @@ import math
 from enum import Enum
 
 import numpy as np
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.utils.serialization import TypedBaseModel
 
 

--- a/propertyestimator/tests/test_client_server.py
+++ b/propertyestimator/tests/test_client_server.py
@@ -12,7 +12,6 @@ from propertyestimator.properties import Density
 from propertyestimator.server import PropertyEstimatorServer
 from propertyestimator.storage import LocalFileStorage
 from propertyestimator.tests.utils import create_dummy_property
-from propertyestimator.utils import get_data_filename
 from propertyestimator.utils.exceptions import PropertyEstimatorException
 
 

--- a/propertyestimator/tests/test_datasets.py
+++ b/propertyestimator/tests/test_datasets.py
@@ -3,8 +3,8 @@ Units tests for propertyestimator.datasets
 """
 
 import pytest
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.datasets import ThermoMLDataSet, PhysicalPropertyDataSet
 from propertyestimator.datasets.plugins import register_thermoml_property
 from propertyestimator.datasets.thermoml import unit_from_thermoml_string

--- a/propertyestimator/tests/test_storage.py
+++ b/propertyestimator/tests/test_storage.py
@@ -4,14 +4,12 @@ Units tests for propertyestimator.storage
 import os
 import tempfile
 
-from simtk import unit
-
+from propertyestimator import unit
 from propertyestimator.storage import LocalFileStorage, StoredSimulationData
 from propertyestimator.storage.dataclasses import BaseStoredData, StoredDataCollection
 from propertyestimator.substances import Substance
 from propertyestimator.tests.utils import create_dummy_stored_simulation_data, create_dummy_substance
 from propertyestimator.thermodynamics import ThermodynamicState
-from propertyestimator.utils import get_data_filename
 
 
 class DummyDataClass1(BaseStoredData):

--- a/propertyestimator/tests/test_utils/test_openmm.py
+++ b/propertyestimator/tests/test_utils/test_openmm.py
@@ -1,0 +1,166 @@
+import inspect
+from random import random
+
+import numpy as np
+import pytest
+from simtk import unit as simtk_unit
+
+from propertyestimator import unit
+from propertyestimator.utils.openmm import openmm_quantity_to_pint, pint_quantity_to_openmm, openmm_unit_to_pint, \
+    pint_unit_to_openmm
+
+
+def _get_all_openmm_units():
+    """Returns a list of all of the defined OpenMM units.
+
+    Returns
+    -------
+    list of simtk.unit.Unit
+    """
+
+    all_openmm_units = set([unit_type for _, unit_type in inspect.getmembers(simtk_unit)
+                           if isinstance(unit_type, simtk_unit.Unit)])
+
+    # There are some units known to not be supported
+    excluded_units = {
+        simtk_unit.yottojoule,
+        simtk_unit.item,
+        simtk_unit.yottopascal,
+        simtk_unit.century,
+        simtk_unit.yottosecond,
+        simtk_unit.yottogram,
+        simtk_unit.bohr,
+        simtk_unit.yottocalorie,
+        simtk_unit.yottoliter,
+        simtk_unit.yottometer,
+        simtk_unit.debye,
+        simtk_unit.yottonewton,
+        simtk_unit.ban,
+        simtk_unit.yottomolar,
+        simtk_unit.nat,
+        simtk_unit.mmHg,
+        simtk_unit.year,
+        simtk_unit.psi,
+        simtk_unit.pound_mass,
+        simtk_unit.stone,
+        simtk_unit.millenium
+    }
+
+    all_openmm_units = all_openmm_units.difference(excluded_units)
+
+    return all_openmm_units
+
+
+def _get_all_pint_units():
+    """Returns a list of all of the pint units which
+    could be converted from all OpenMM units.
+
+    Returns
+    -------
+    list of pint.Unit
+    """
+
+    all_openmm_units = _get_all_openmm_units()
+
+    all_pint_units = [openmm_unit_to_pint(openmm_unit) for openmm_unit in all_openmm_units]
+    return all_pint_units
+
+
+@pytest.mark.parametrize("openmm_unit", _get_all_openmm_units())
+def test_openmm_unit_to_pint(openmm_unit):
+
+    openmm_quantity = random() * openmm_unit
+    openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
+
+    pint_quantity = openmm_quantity_to_pint(openmm_quantity)
+    pint_raw_value = pint_quantity.magnitude
+
+    assert np.isclose(openmm_raw_value, pint_raw_value)
+
+
+@pytest.mark.parametrize("pint_unit", _get_all_pint_units())
+def test_pint_to_openmm(pint_unit):
+
+    pint_quantity = random() * pint_unit
+    pint_raw_value = pint_quantity.magnitude
+
+    openmm_quantity = pint_quantity_to_openmm(pint_quantity)
+    openmm_raw_value = openmm_quantity.value_in_unit(openmm_quantity.unit)
+
+    assert np.isclose(openmm_raw_value, pint_raw_value)
+
+
+def test_combinatorial_pint_to_openmm():
+
+    all_pint_units = _get_all_pint_units()
+
+    for i in range(len(all_pint_units)):
+
+        for j in range(i, len(all_pint_units)):
+
+            pint_unit = all_pint_units[i] * all_pint_units[j]
+
+            pint_quantity = random() * pint_unit
+            pint_raw_value = pint_quantity.magnitude
+
+            openmm_quantity = pint_quantity_to_openmm(pint_quantity)
+            openmm_raw_value = openmm_quantity.value_in_unit(openmm_quantity.unit)
+
+            assert np.isclose(openmm_raw_value, pint_raw_value)
+
+
+def test_combinatorial_openmm_to_pint():
+
+    all_openmm_units = list(_get_all_openmm_units())
+
+    for i in range(len(all_openmm_units)):
+
+        for j in range(i, len(all_openmm_units)):
+
+            openmm_unit = all_openmm_units[i] * all_openmm_units[j]
+
+            openmm_quantity = random() * openmm_unit
+            openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
+
+            pint_quantity = openmm_quantity_to_pint(openmm_quantity)
+            pint_raw_value = pint_quantity.magnitude
+
+            assert np.isclose(openmm_raw_value, pint_raw_value)
+
+
+@pytest.mark.parametrize("openmm_unit", _get_all_openmm_units())
+def test_openmm_unit_conversions(openmm_unit):
+
+    openmm_quantity = random() * openmm_unit
+
+    openmm_base_quantity = openmm_quantity.in_unit_system(simtk_unit.md_unit_system)
+    pint_base_quantity = openmm_quantity_to_pint(openmm_base_quantity)
+
+    pint_unit = openmm_unit_to_pint(openmm_unit)
+    pint_quantity = pint_base_quantity.to(pint_unit)
+
+    pint_raw_value = pint_quantity.magnitude
+    openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
+
+    assert np.isclose(openmm_raw_value, pint_raw_value)
+
+
+@pytest.mark.parametrize("pint_unit", _get_all_pint_units())
+def test_pint_unit_conversions(pint_unit):
+
+    pint_quantity = random() * pint_unit
+
+    pint_base_quantity = pint_quantity.to_base_units()
+    openmm_base_quantity = pint_quantity_to_openmm(pint_base_quantity)
+
+    openmm_unit = pint_unit_to_openmm(pint_unit)
+    openmm_quantity = openmm_base_quantity.in_units_of(openmm_unit)
+
+    pint_raw_value = pint_quantity.magnitude
+
+    if pint_unit == unit.dimensionless and isinstance(openmm_quantity, float):
+        openmm_raw_value = openmm_quantity
+    else:
+        openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
+
+    assert np.isclose(openmm_raw_value, pint_raw_value)

--- a/propertyestimator/tests/test_utils/test_openmm.py
+++ b/propertyestimator/tests/test_utils/test_openmm.py
@@ -7,7 +7,7 @@ from simtk import unit as simtk_unit
 
 from propertyestimator import unit
 from propertyestimator.utils.openmm import openmm_quantity_to_pint, pint_quantity_to_openmm, openmm_unit_to_pint, \
-    pint_unit_to_openmm
+    pint_unit_to_openmm, unsupported_openmm_units
 
 
 def _get_all_openmm_units():
@@ -21,32 +21,7 @@ def _get_all_openmm_units():
     all_openmm_units = set([unit_type for _, unit_type in inspect.getmembers(simtk_unit)
                            if isinstance(unit_type, simtk_unit.Unit)])
 
-    # There are some units known to not be supported
-    excluded_units = {
-        simtk_unit.yottojoule,
-        simtk_unit.item,
-        simtk_unit.yottopascal,
-        simtk_unit.century,
-        simtk_unit.yottosecond,
-        simtk_unit.yottogram,
-        simtk_unit.bohr,
-        simtk_unit.yottocalorie,
-        simtk_unit.yottoliter,
-        simtk_unit.yottometer,
-        simtk_unit.debye,
-        simtk_unit.yottonewton,
-        simtk_unit.ban,
-        simtk_unit.yottomolar,
-        simtk_unit.nat,
-        simtk_unit.mmHg,
-        simtk_unit.year,
-        simtk_unit.psi,
-        simtk_unit.pound_mass,
-        simtk_unit.stone,
-        simtk_unit.millenium
-    }
-
-    all_openmm_units = all_openmm_units.difference(excluded_units)
+    all_openmm_units = all_openmm_units.difference(unsupported_openmm_units)
 
     return all_openmm_units
 
@@ -64,6 +39,7 @@ def _get_all_pint_units():
 
     all_pint_units = [openmm_unit_to_pint(openmm_unit) for openmm_unit in all_openmm_units]
     return all_pint_units
+
 
 @pytest.mark.parametrize("openmm_unit", _get_all_openmm_units())
 @pytest.mark.parametrize("value", [random(), randint(1, 10), [random(), random()], np.array([random(), random()])])

--- a/propertyestimator/tests/test_utils/test_openmm.py
+++ b/propertyestimator/tests/test_utils/test_openmm.py
@@ -41,6 +41,17 @@ def _get_all_pint_units():
     return all_pint_units
 
 
+def test_daltons():
+
+    openmm_quantity = random() * simtk_unit.dalton
+    openmm_raw_value = openmm_quantity.value_in_unit(simtk_unit.gram / simtk_unit.mole)
+
+    pint_quantity = openmm_quantity_to_pint(openmm_quantity)
+    pint_raw_value = pint_quantity.to(unit.gram / unit.mole).magnitude
+
+    assert np.allclose(openmm_raw_value, pint_raw_value)
+
+
 @pytest.mark.parametrize("openmm_unit", _get_all_openmm_units())
 @pytest.mark.parametrize("value", [random(), randint(1, 10), [random(), random()], np.array([random(), random()])])
 def test_openmm_unit_to_pint(openmm_unit, value):
@@ -105,7 +116,7 @@ def test_combinatorial_openmm_to_pint():
             assert np.isclose(openmm_raw_value, pint_raw_value)
 
 
-@pytest.mark.parametrize("openmm_unit", _get_all_openmm_units())
+@pytest.mark.parametrize("openmm_unit", {*_get_all_openmm_units(), simtk_unit.dalton**2, simtk_unit.dalton**3})
 @pytest.mark.parametrize("value", [random(), randint(1, 10), [random(), random()], np.array([random(), random()])])
 def test_openmm_unit_conversions(openmm_unit, value):
 
@@ -153,10 +164,28 @@ def test_pint_unit_conversions(pint_unit, value):
 
 
 def test_constants():
+
     assert np.isclose(simtk_unit.AVOGADRO_CONSTANT_NA.value_in_unit((1.0 / simtk_unit.mole).unit),
                       (1.0 * unit.avogadro_number).to((1.0 / unit.mole).units))
-    assert np.isclose(simtk_unit.BOLTZMANN_CONSTANT_kB.value_in_unit(simtk_unit.joule / simtk_unit.kelvin),
-                      (1.0 * unit.boltzmann_constant).to(unit.joule / unit.kelvin))
+
+    assert np.isclose(simtk_unit.BOLTZMANN_CONSTANT_kB.value_in_unit(simtk_unit.joule /
+                                                                     simtk_unit.kelvin),
+                      (1.0 * unit.boltzmann_constant).to(unit.joule /
+                                                         unit.kelvin))
+
     assert np.isclose(simtk_unit.MOLAR_GAS_CONSTANT_R.value_in_unit(simtk_unit.joule /
-                                                                    simtk_unit.kelvin / simtk_unit.mole),
-                      (1.0 * unit.molar_gas_constant).to(unit.joule / unit.kelvin / unit.mole))
+                                                                    simtk_unit.kelvin /
+                                                                    simtk_unit.mole),
+                      (1.0 * unit.molar_gas_constant).to(unit.joule /
+                                                         unit.kelvin /
+                                                         unit.mole))
+
+    assert np.isclose(simtk_unit.GRAVITATIONAL_CONSTANT_G.value_in_unit(simtk_unit.meter**2 *
+                                                                        simtk_unit.newton /
+                                                                        simtk_unit.kilogram**2),
+                      (1.0 * unit.newtonian_constant_of_gravitation).to(unit.meter**2 *
+                                                                        unit.newton /
+                                                                        unit.kilogram**2))
+
+    assert np.isclose(simtk_unit.SPEED_OF_LIGHT_C.value_in_unit(simtk_unit.meter / simtk_unit.seconds),
+                      (1.0 * unit.speed_of_light).to(unit.meter / unit.seconds))

--- a/propertyestimator/tests/test_utils/test_quantities.py
+++ b/propertyestimator/tests/test_utils/test_quantities.py
@@ -3,8 +3,8 @@ for the EstimatedQuantity class.
 """
 
 import pytest
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.utils import quantities
 
 

--- a/propertyestimator/tests/test_utils/test_serialization.py
+++ b/propertyestimator/tests/test_utils/test_serialization.py
@@ -1,15 +1,13 @@
 """
 Units tests for propertyestimator.utils.serialization
 """
-import numpy as np
-
 import json
 from enum import Enum, IntEnum
 
+import numpy as np
 import pytest
-from simtk import unit
 
-from propertyestimator.utils import get_data_filename
+from propertyestimator import unit
 from propertyestimator.utils.serialization import serialize_force_field, deserialize_force_field, \
     TypedBaseModel, TypedJSONEncoder, TypedJSONDecoder, serialize_quantity, deserialize_quantity
 
@@ -238,7 +236,7 @@ def test_dimensionless_quantity_serialization():
 
     assert test_value == deserialized_value
 
-    test_value = unit.Quantity(1.0, None)
+    test_value = unit.Quantity(1.0)
 
     serialized_value = serialize_quantity(test_value)
     deserialized_value = deserialize_quantity(serialized_value)

--- a/propertyestimator/tests/test_utils/test_statistics.py
+++ b/propertyestimator/tests/test_utils/test_statistics.py
@@ -5,8 +5,8 @@ import os
 
 import numpy as np
 import pytest
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.utils import get_data_filename
 from propertyestimator.utils.statistics import StatisticsArray, bootstrap, ObservableType
 

--- a/propertyestimator/tests/test_utils/test_string.py
+++ b/propertyestimator/tests/test_utils/test_string.py
@@ -2,7 +2,6 @@
 Units tests for propertyestimator.utils.statistics
 """
 import pytest
-from simtk import unit
 
 from propertyestimator.utils import string
 

--- a/propertyestimator/tests/test_workflow/test_gradients.py
+++ b/propertyestimator/tests/test_workflow/test_gradients.py
@@ -5,8 +5,8 @@ import tempfile
 from os import path
 
 from openforcefield.typing.engines import smirnoff
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.backends import ComputeResources, DaskLocalCluster
 from propertyestimator.client import PropertyEstimatorClient, PropertyEstimatorOptions, ConnectionOptions
 from propertyestimator.datasets import PhysicalPropertyDataSet
@@ -17,7 +17,6 @@ from propertyestimator.server import PropertyEstimatorServer
 from propertyestimator.storage import LocalFileStorage
 from propertyestimator.substances import Substance
 from propertyestimator.thermodynamics import Ensemble, ThermodynamicState
-from propertyestimator.utils import get_data_filename
 from propertyestimator.utils.exceptions import PropertyEstimatorException
 from propertyestimator.workflow import WorkflowOptions
 

--- a/propertyestimator/tests/test_workflow/test_protocols.py
+++ b/propertyestimator/tests/test_workflow/test_protocols.py
@@ -5,9 +5,9 @@ import tempfile
 from os import path
 
 import pytest
-from simtk import unit
 from simtk.openmm.app import PDBFile
 
+from propertyestimator import unit
 from propertyestimator.backends import ComputeResources
 from propertyestimator.properties.dielectric import ExtractAverageDielectric
 from propertyestimator.protocols.analysis import ExtractAverageStatistic, ExtractUncorrelatedTrajectoryData, \

--- a/propertyestimator/tests/test_workflow/test_workflow.py
+++ b/propertyestimator/tests/test_workflow/test_workflow.py
@@ -5,8 +5,8 @@ import tempfile
 from collections import OrderedDict
 
 import pytest
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.backends import DaskLocalCluster, ComputeResources
 from propertyestimator.layers import available_layers
 from propertyestimator.layers.layers import CalculationLayerResult
@@ -21,7 +21,7 @@ from propertyestimator.tests.test_workflow.utils import DummyReplicableProtocol,
     DummyEstimatedQuantityProtocol
 from propertyestimator.tests.utils import create_dummy_property
 from propertyestimator.thermodynamics import ThermodynamicState
-from propertyestimator.utils import get_data_filename, graph
+from propertyestimator.utils import graph
 from propertyestimator.utils.quantities import EstimatedQuantity
 from propertyestimator.workflow import WorkflowOptions, WorkflowSchema
 from propertyestimator.workflow.schemas import ProtocolReplicator

--- a/propertyestimator/tests/test_workflow/utils.py
+++ b/propertyestimator/tests/test_workflow/utils.py
@@ -1,7 +1,4 @@
-from simtk import unit
-
-from propertyestimator.client import PropertyEstimatorOptions
-from propertyestimator.utils import get_data_filename
+from propertyestimator import unit
 from propertyestimator.utils.quantities import EstimatedQuantity
 from propertyestimator.workflow import Workflow
 from propertyestimator.workflow.decorators import protocol_input, protocol_output

--- a/propertyestimator/tests/utils.py
+++ b/propertyestimator/tests/utils.py
@@ -23,7 +23,8 @@ class BackendType(Enum):
     CPU = 'CPU'
 
 
-def setup_server(backend_type=BackendType.LocalCPU, max_number_of_workers=1, conda_environment='propertyestimator'):
+def setup_server(backend_type=BackendType.LocalCPU, max_number_of_workers=1,
+                 conda_environment='propertyestimator', worker_memory=8 * unit.gigabyte):
 
     working_directory = 'working_directory'
     storage_directory = 'storage_directory'
@@ -50,7 +51,7 @@ def setup_server(backend_type=BackendType.LocalCPU, max_number_of_workers=1, con
         queue_resources = QueueWorkerResources(number_of_threads=1,
                                                number_of_gpus=1,
                                                preferred_gpu_toolkit=QueueWorkerResources.GPUToolkit.CUDA,
-                                               per_thread_memory_limit=12 * (unit.gigabyte),
+                                               per_thread_memory_limit=worker_memory,
                                                wallclock_time_limit="05:59")
 
         worker_script_commands = [
@@ -74,7 +75,7 @@ def setup_server(backend_type=BackendType.LocalCPU, max_number_of_workers=1, con
     elif backend_type == BackendType.CPU:
 
         queue_resources = QueueWorkerResources(number_of_threads=1,
-                                               per_thread_memory_limit=10 * (unit.gigabyte),
+                                               per_thread_memory_limit=worker_memory,
                                                wallclock_time_limit="01:30")
 
         worker_script_commands = [

--- a/propertyestimator/tests/utils.py
+++ b/propertyestimator/tests/utils.py
@@ -1,9 +1,9 @@
-import json
 import os
 import shutil
 from enum import Enum
 
 from propertyestimator import server
+from propertyestimator import unit
 from propertyestimator.backends import DaskLocalCluster, ComputeResources, QueueWorkerResources, DaskLSFBackend
 from propertyestimator.datasets import PhysicalPropertyDataSet
 from propertyestimator.properties import Density
@@ -13,9 +13,7 @@ from propertyestimator.storage import LocalFileStorage, StoredSimulationData
 from propertyestimator.substances import Substance
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils import get_data_filename
-from propertyestimator.utils.serialization import TypedJSONEncoder
 from propertyestimator.workflow import WorkflowOptions
-from simtk import unit
 
 
 class BackendType(Enum):
@@ -52,7 +50,7 @@ def setup_server(backend_type=BackendType.LocalCPU, max_number_of_workers=1, con
         queue_resources = QueueWorkerResources(number_of_threads=1,
                                                number_of_gpus=1,
                                                preferred_gpu_toolkit=QueueWorkerResources.GPUToolkit.CUDA,
-                                               per_thread_memory_limit=12 * (unit.giga * unit.byte),
+                                               per_thread_memory_limit=12 * (unit.gigabyte),
                                                wallclock_time_limit="05:59")
 
         worker_script_commands = [
@@ -76,7 +74,7 @@ def setup_server(backend_type=BackendType.LocalCPU, max_number_of_workers=1, con
     elif backend_type == BackendType.CPU:
 
         queue_resources = QueueWorkerResources(number_of_threads=1,
-                                               per_thread_memory_limit=10 * (unit.giga * unit.byte),
+                                               per_thread_memory_limit=10 * (unit.gigabyte),
                                                wallclock_time_limit="01:30")
 
         worker_script_commands = [
@@ -287,8 +285,8 @@ def create_filterable_data_set():
                                                                                 pressure=1.5 * unit.atmosphere),
                                          phase=PropertyPhase.Solid,
                                          substance=oxygen_substance,
-                                         value=1 * unit.kilojoules_per_mole,
-                                         uncertainty=0.11 * unit.kilojoules_per_mole,
+                                         value=1 * unit.kilojoules / unit.mole,
+                                         uncertainty=0.11 * unit.kilojoules / unit.mole,
                                          source=source)
 
     data_set = PhysicalPropertyDataSet()

--- a/propertyestimator/thermodynamics.py
+++ b/propertyestimator/thermodynamics.py
@@ -4,8 +4,7 @@ Defines an API for defining thermodynamic states.
 import math
 from enum import Enum
 
-from simtk import unit
-
+from propertyestimator import unit
 from propertyestimator.utils.serialization import TypedBaseModel
 
 
@@ -22,9 +21,9 @@ class ThermodynamicState(TypedBaseModel):
 
     Attributes
     ----------
-    temperature : simtk.unit.Quantity with units compatible with kelvin
+    temperature : propertyestimator.unit.Quantity with units compatible with kelvin
         The external temperature
-    pressure : simtk.unit.Quantity with units compatible with atmospheres
+    pressure : propertyestimator.unit.Quantity with units compatible with atmospheres
         The external pressure
 
     Examples
@@ -42,9 +41,9 @@ class ThermodynamicState(TypedBaseModel):
 
         Parameters
         ----------
-        temperature : simtk.unit.Quantity with units compatible with kelvin
+        temperature : propertyestimator.unit.Quantity with units compatible with kelvin
             The external temperature
-        pressure : simtk.unit.Quantity with units compatible with atmospheres
+        pressure : propertyestimator.unit.Quantity with units compatible with atmospheres
             The external pressure
         """
 
@@ -96,8 +95,10 @@ class ThermodynamicState(TypedBaseModel):
         if not isinstance(other, ThermodynamicState):
             return False
 
-        return (math.isclose(self.temperature / unit.kelvin, other.temperature / unit.kelvin) and
-                math.isclose(self.pressure / unit.atmosphere, other.pressure / unit.atmosphere))
+        return (math.isclose(self.temperature.to(unit.kelvin).magnitude,
+                             other.temperature.to(unit.kelvin).magnitude) and
+                math.isclose(self.pressure.to(unit.atmosphere).magnitude,
+                             other.pressure.to(unit.atmosphere).magnitude))
 
     def __ne__(self, other):
         return not (self == other)

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -4,6 +4,10 @@ A set of utilities for helping to perform simulations using openmm.
 import logging
 import os
 
+from pint import UndefinedUnitError
+
+from propertyestimator import unit
+
 
 def setup_platform_with_resources(compute_resources, high_precision=False):
     """Creates an OpenMM `Platform` object which requests a set
@@ -68,6 +72,114 @@ def setup_platform_with_resources(compute_resources, high_precision=False):
         logging.info('Setting up a simulation with {} threads'.format(compute_resources.number_of_threads))
 
     return platform
+
+
+def openmm_quantity_to_pint(openmm_quantity):
+    """Converts a `simtk.unit.Quantity` to a `pint.Quantity`.
+
+    Parameters
+    ----------
+    openmm_quantity: simtk.unit.Quantity
+        The quantity to convert.
+
+    Returns
+    -------
+    pint.Quantity
+        The converted quantity.
+    """
+
+    if isinstance(openmm_quantity, float):
+        return openmm_quantity * unit.dimensionless
+
+    openmm_unit = openmm_quantity.unit
+    openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
+
+    pint_unit = openmm_unit_to_pint(openmm_unit)
+    pint_quantity = openmm_raw_value * pint_unit
+
+    return pint_quantity
+
+
+def openmm_unit_to_pint(openmm_unit):
+    """Converts a `simtk.unit.Unit` to a `pint.Unit`.
+
+    Parameters
+    ----------
+    openmm_unit: simtk.unit.Unit
+        The unit to convert.
+
+    Returns
+    -------
+    pint.Unit
+        The converted unit.
+    """
+    from openforcefield.utils import unit_to_string
+
+    openmm_unit_string = unit_to_string(openmm_unit)
+
+    try:
+        pint_unit = unit(openmm_unit_string).units
+    except UndefinedUnitError:
+
+        logging.info(f'The {openmm_unit_string} OMM unit string (based on the {openmm_unit} object) '
+                     f'is undefined in pint')
+
+        raise
+
+    return pint_unit
+
+
+def pint_quantity_to_openmm(pint_quantity):
+    """Converts a `pint.Quantity` to a `simtk.unit.Quantity`.
+
+    Parameters
+    ----------
+    pint_quantity: pint.Quantity
+        The quantity to convert.
+
+    Returns
+    -------
+    simtk.unit.Quantity
+        The converted quantity.
+    """
+
+    pint_unit = pint_quantity.units
+    pint_raw_value = pint_quantity.magnitude
+
+    openmm_unit = pint_unit_to_openmm(pint_unit)
+    openmm_quantity = pint_raw_value * openmm_unit
+
+    return openmm_quantity
+
+
+def pint_unit_to_openmm(pint_unit):
+    """Converts a `pint.Unit` to a `simtk.unit.Unit`.
+
+    Parameters
+    ----------
+    pint_unit: pint.Unit
+        The unit to convert.
+
+    Returns
+    -------
+    simtk.unit.Unit
+        The converted unit.
+    """
+    from openforcefield.utils import string_to_unit
+
+    pint_unit_string = str(pint_unit)
+
+    try:
+        # noinspection PyTypeChecker
+        openmm_unit = string_to_unit(pint_unit_string)
+    except AttributeError:
+
+        logging.info(f'The {pint_unit_string} pint unit string (based on the {pint_unit} object) '
+                     f'could not be understood by `openforcefield.utils.string_to_unit`')
+
+        raise
+
+    return openmm_unit
 
 
 class StateReporter:

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -88,8 +88,8 @@ def openmm_quantity_to_pint(openmm_quantity):
         The converted quantity.
     """
 
-    if isinstance(openmm_quantity, float):
-        return openmm_quantity * unit.dimensionless
+    from simtk import unit as simtk_unit
+    assert isinstance(openmm_quantity, simtk_unit.Quantity)
 
     openmm_unit = openmm_quantity.unit
     openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
@@ -114,6 +114,9 @@ def openmm_unit_to_pint(openmm_unit):
         The converted unit.
     """
     from openforcefield.utils import unit_to_string
+
+    from simtk import unit as simtk_unit
+    assert isinstance(openmm_unit, simtk_unit.Unit)
 
     openmm_unit_string = unit_to_string(openmm_unit)
 
@@ -143,6 +146,8 @@ def pint_quantity_to_openmm(pint_quantity):
         The converted quantity.
     """
 
+    assert isinstance(pint_quantity, unit.Quantity)
+
     pint_unit = pint_quantity.units
     pint_raw_value = pint_quantity.magnitude
 
@@ -166,6 +171,8 @@ def pint_unit_to_openmm(pint_unit):
         The converted unit.
     """
     from openforcefield.utils import string_to_unit
+
+    assert isinstance(pint_unit, unit.Unit)
 
     pint_unit_string = str(pint_unit)
 

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -115,6 +115,9 @@ def openmm_quantity_to_pint(openmm_quantity):
         The converted quantity.
     """
 
+    if openmm_quantity is None:
+        return None
+
     assert isinstance(openmm_quantity, simtk_unit.Quantity)
 
     if openmm_quantity.unit in unsupported_openmm_units:
@@ -146,6 +149,9 @@ def openmm_unit_to_pint(openmm_unit):
     """
     from openforcefield.utils import unit_to_string
 
+    if openmm_unit is None:
+        return None
+
     assert isinstance(openmm_unit, simtk_unit.Unit)
 
     if openmm_unit in unsupported_openmm_units:
@@ -154,6 +160,12 @@ def openmm_unit_to_pint(openmm_unit):
                          f'currently supported by pint.')
 
     openmm_unit_string = unit_to_string(openmm_unit)
+
+    # Handle the case whereby OMM treats daltons as having
+    # units of g / mol, whereas SI and pint define them to
+    # have units of kg.
+    openmm_unit_string = (None if openmm_unit_string is None else
+                          openmm_unit_string.replace('dalton', '(gram / mole)'))
 
     try:
         pint_unit = unit(openmm_unit_string).units
@@ -185,6 +197,9 @@ def pint_quantity_to_openmm(pint_quantity):
         The converted quantity.
     """
 
+    if pint_quantity is None:
+        return None
+
     assert isinstance(pint_quantity, unit.Quantity)
 
     pint_unit = pint_quantity.units
@@ -214,6 +229,9 @@ def pint_unit_to_openmm(pint_unit):
         The converted unit.
     """
     from openforcefield.utils import string_to_unit
+
+    if pint_unit is None:
+        return None
 
     assert isinstance(pint_unit, unit.Unit)
 

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -7,6 +7,7 @@ import os
 from pint import UndefinedUnitError
 
 from propertyestimator import unit
+from simtk import unit as simtk_unit
 
 
 def setup_platform_with_resources(compute_resources, high_precision=False):
@@ -74,6 +75,32 @@ def setup_platform_with_resources(compute_resources, high_precision=False):
     return platform
 
 
+# Some openmm units are not currently supported.
+unsupported_openmm_units = {
+    simtk_unit.yottojoule,
+    simtk_unit.item,
+    simtk_unit.yottopascal,
+    simtk_unit.century,
+    simtk_unit.yottosecond,
+    simtk_unit.yottogram,
+    simtk_unit.bohr,
+    simtk_unit.yottocalorie,
+    simtk_unit.yottoliter,
+    simtk_unit.yottometer,
+    simtk_unit.debye,
+    simtk_unit.yottonewton,
+    simtk_unit.ban,
+    simtk_unit.yottomolar,
+    simtk_unit.nat,
+    simtk_unit.mmHg,
+    simtk_unit.year,
+    simtk_unit.psi,
+    simtk_unit.pound_mass,
+    simtk_unit.stone,
+    simtk_unit.millenium
+}
+
+
 def openmm_quantity_to_pint(openmm_quantity):
     """Converts a `simtk.unit.Quantity` to a `pint.Quantity`.
 
@@ -88,8 +115,12 @@ def openmm_quantity_to_pint(openmm_quantity):
         The converted quantity.
     """
 
-    from simtk import unit as simtk_unit
     assert isinstance(openmm_quantity, simtk_unit.Quantity)
+
+    if openmm_quantity.unit in unsupported_openmm_units:
+
+        raise ValueError(f'Quantities bearing the {openmm_quantity.unit} are not '
+                         f'currently supported by pint.')
 
     openmm_unit = openmm_quantity.unit
     openmm_raw_value = openmm_quantity.value_in_unit(openmm_unit)
@@ -115,8 +146,12 @@ def openmm_unit_to_pint(openmm_unit):
     """
     from openforcefield.utils import unit_to_string
 
-    from simtk import unit as simtk_unit
     assert isinstance(openmm_unit, simtk_unit.Unit)
+
+    if openmm_unit in unsupported_openmm_units:
+
+        raise ValueError(f'Quantities bearing the {openmm_unit} are not '
+                         f'currently supported by pint.')
 
     openmm_unit_string = unit_to_string(openmm_unit)
 
@@ -134,6 +169,10 @@ def openmm_unit_to_pint(openmm_unit):
 
 def pint_quantity_to_openmm(pint_quantity):
     """Converts a `pint.Quantity` to a `simtk.unit.Quantity`.
+
+    Notes
+    -----
+    Not all pint units are available in OpenMM.
 
     Parameters
     ----------
@@ -159,6 +198,10 @@ def pint_quantity_to_openmm(pint_quantity):
 
 def pint_unit_to_openmm(pint_unit):
     """Converts a `pint.Unit` to a `simtk.unit.Unit`.
+
+    Notes
+    -----
+    Not all pint units are available in OpenMM.
 
     Parameters
     ----------

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -391,7 +391,8 @@ def _correct_packmol_output(file_path, molecule_topologies,
 
             offset += molecule_topology.n_atoms
 
-    all_bonds = np.unique(all_bonds, axis=0).tolist()
+    if len(all_bonds) > 0:
+        all_bonds = np.unique(all_bonds, axis=0).tolist()
 
     # We have to check whether there are any existing bonds, because mdtraj will
     # sometimes automatically detect some based on residue names (e.g HOH), and

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -17,8 +17,8 @@ from distutils.spawn import find_executable
 
 import numpy as np
 from simtk import openmm
-from simtk import unit
 
+from propertyestimator import unit
 from propertyestimator.utils.utils import temporarily_change_directory
 
 PACKMOL_PATH = find_executable("packmol") or shutil.which("packmol") or \
@@ -72,10 +72,10 @@ def pack_box(molecules,
         A file path to the PDB coordinates of the structure to be solvated.
     tolerance : float
         The minimum spacing between molecules during packing in angstroms.
-    box_size : simtk.unit.Quantity, optional
+    box_size : propertyestimator.unit.Quantity, optional
         The size of the box to generate in units compatible with angstroms. If `None`,
         `mass_density` must be provided.
-    mass_density : simtk.unit.Quantity, optional
+    mass_density : propertyestimator.unit.Quantity, optional
         Target mass density for final system with units compatible with g/mL. If `None`,
         `box_size` must be provided.
     box_aspect_ratio: list of float, optional
@@ -94,8 +94,8 @@ def pack_box(molecules,
     -------
     topology : simtk.openmm.Topology
         Topology of the resulting system
-    positions : simtk.unit.Quantity
-        A `simtk.unit.Quantity` wrapped `numpy.ndarray` (shape=[natoms,3]) which contains
+    positions : propertyestimator.unit.Quantity
+        A `propertyestimator.unit.Quantity` wrapped `numpy.ndarray` (shape=[natoms,3]) which contains
         the created positions with units compatible with angstroms.
     """
 
@@ -104,7 +104,7 @@ def pack_box(molecules,
 
     if box_size is not None and len(box_size) != 3:
 
-        raise ValueError('`box_size` must be a simtk.unit.Quantity '
+        raise ValueError('`box_size` must be a propertyestimator.unit.Quantity '
                          'wrapped list of length 3')
 
     if mass_density is not None and box_aspect_ratio is None:
@@ -172,7 +172,7 @@ def pack_box(molecules,
                                                             number_of_copies,
                                                             mass_density)
 
-        initial_box_length_angstrom = initial_box_length.value_in_unit(unit.angstrom)
+        initial_box_length_angstrom = initial_box_length.to(unit.angstrom).magnitude
 
         aspect_ratio_normalizer = (box_aspect_ratio[0] *
                                    box_aspect_ratio[1] *
@@ -186,7 +186,7 @@ def pack_box(molecules,
 
         box_size /= aspect_ratio_normalizer
 
-    unitless_box_angstrom = box_size.value_in_unit(unit.angstrom)
+    unitless_box_angstrom = box_size.to(unit.angstrom).magnitude
 
     packmol_input = _HEADER_TEMPLATE.format(tolerance, output_file_name)
 
@@ -265,13 +265,14 @@ def pack_box(molecules,
 
     # Add a 2 angstrom buffer to help alleviate PBC issues.
     box_vectors = [
-        openmm.Vec3((box_size[0] + 2.0 * unit.angstrom).value_in_unit(unit.nanometers), 0, 0),
-        openmm.Vec3(0, (box_size[1] + 2.0 * unit.angstrom).value_in_unit(unit.nanometers), 0),
-        openmm.Vec3(0, 0, (box_size[2] + 2.0 * unit.angstrom).value_in_unit(unit.nanometers))
+        openmm.Vec3((box_size[0] + 2.0 * unit.angstrom).to(unit.nanometers).magnitude, 0, 0),
+        openmm.Vec3(0, (box_size[1] + 2.0 * unit.angstrom).to(unit.nanometers).magnitude, 0),
+        openmm.Vec3(0, 0, (box_size[2] + 2.0 * unit.angstrom).to(unit.nanometers).magnitude)
     ]
 
     # Set the periodic box vectors.
-    topology.setPeriodicBoxVectors(box_vectors * unit.nanometers)
+    from simtk import unit as simtk_unit
+    topology.setPeriodicBoxVectors(box_vectors * simtk_unit.nanometers)
 
     return topology, positions
 
@@ -291,20 +292,21 @@ def _approximate_volume_by_density(molecules,
         Number of copies of the molecules.
     box_scaleup_factor : float, optional, default = 1.1
         Factor by which the estimated box size is increased
-    mass_density : simtk.unit.Quantity with units compatible with grams/milliliters, optional,
-                   default = 1.0*grams/milliliters
-        Target mass density for final system, if available.
+    mass_density : propertyestimator.unit.Quantity, optional
+        The target mass density for final system, if available.
+        It should have units compatible with grams/milliliters.
 
     Returns
     -------
-    box_edge : simtk.unit.Quantity with units compatible with angstroms
-        The size (edge length) of the box to generate.
+    box_edge : propertyestimator.unit.Quantity
+        The size (edge length) of the box to generate in units
+        compatible with angstroms.
 
     Notes
     -----
-    By default, boxes are only modestly large. This approach has not been extensively tested for stability but has been
-    used in the Mobley lab for perhaps ~100 different systems without substantial problems.
-
+    By default, boxes are only modestly large. This approach has not been
+    extensively tested for stability but has been used in the Mobley lab
+    for perhaps ~100 different systems without substantial problems.
     """
     from openeye import oechem
 
@@ -314,7 +316,7 @@ def _approximate_volume_by_density(molecules,
     for (molecule, number) in zip(molecules, n_copies):
 
         molecule_mass = oechem.OECalculateMolecularWeight(molecule) * \
-                        unit.grams / unit.mole / unit.AVOGADRO_CONSTANT_NA
+                        unit.grams / unit.mole / unit.avogadro_number
 
         molecule_volume = molecule_mass / mass_density
 
@@ -352,13 +354,14 @@ def _correct_packmol_output(file_path, molecule_topologies,
     """
 
     import mdtraj
+    from simtk import unit as simtk_unit
 
     trajectory = mdtraj.load(file_path)
 
     atoms_data_frame, _ = trajectory.topology.to_dataframe()
 
     all_bonds = []
-    all_positions = trajectory.openmm_positions(0)
+    all_positions = trajectory.openmm_positions(0).value_in_unit(simtk_unit.angstrom) * unit.angstrom
 
     all_topologies = []
     all_copies = []

--- a/propertyestimator/utils/quantities.py
+++ b/propertyestimator/utils/quantities.py
@@ -227,12 +227,13 @@ class EstimatedQuantity:
             The unit of the values encoded in the ufloat object.
         """
 
-        value_unit = estimated_quantity.value.units
+        base_value = estimated_quantity.value.to_base_units()
+        base_value_unit = base_value.units
 
-        unitless_value = estimated_quantity.value.magnitude
-        unitless_uncertainty = estimated_quantity.uncertainty.to(value_unit).magnitude
+        unitless_value = base_value.magnitude
+        unitless_uncertainty = estimated_quantity.uncertainty.to(base_value_unit).magnitude
 
-        return ufloat(unitless_value, unitless_uncertainty), value_unit
+        return ufloat(unitless_value, unitless_uncertainty), base_value_unit
 
     def __eq__(self, other):
 

--- a/propertyestimator/utils/quantities.py
+++ b/propertyestimator/utils/quantities.py
@@ -3,8 +3,9 @@ their uncertainties
 """
 
 import numpy as np
-from simtk import unit
 from uncertainties import ufloat
+
+from propertyestimator import unit
 
 
 class EstimatedQuantity:
@@ -31,7 +32,7 @@ class EstimatedQuantity:
     Examples
     --------
     To add two **independent** quantities together:
-    >>> from simtk import unit
+    >>> from propertyestimator import unit
     >>>
     >>> a_value = 5 * unit.angstrom
     >>> a_uncertainty = 0.03 * unit.angstrom
@@ -108,7 +109,7 @@ class EstimatedQuantity:
         assert isinstance(value, unit.Quantity)
         assert isinstance(uncertainty, unit.Quantity)
 
-        assert value.unit.is_compatible(uncertainty.unit)
+        assert unit.get_base_units(value.units)[-1] == unit.get_base_units(uncertainty.units)[-1]
 
         self._value = value
         self._uncertainty = uncertainty
@@ -226,16 +227,10 @@ class EstimatedQuantity:
             The unit of the values encoded in the ufloat object.
         """
 
-        value_in_default_unit_system = estimated_quantity.value.in_unit_system(unit.md_unit_system)
-        uncertainty_in_default_unit_system = estimated_quantity.uncertainty.in_unit_system(unit.md_unit_system)
+        value_unit = estimated_quantity.value.units
 
-        value_unit = value_in_default_unit_system.unit
-        unitless_value = estimated_quantity.value.value_in_unit(value_unit)
-
-        uncertainty_unit = uncertainty_in_default_unit_system.unit
-        unitless_uncertainty = estimated_quantity.uncertainty.value_in_unit(uncertainty_unit)
-
-        assert value_unit == uncertainty_unit
+        unitless_value = estimated_quantity.value.magnitude
+        unitless_uncertainty = estimated_quantity.uncertainty.to(value_unit).magnitude
 
         return ufloat(unitless_value, unitless_uncertainty), value_unit
 

--- a/propertyestimator/workflow/protocols.py
+++ b/propertyestimator/workflow/protocols.py
@@ -6,7 +6,6 @@ form a larger property estimation workflow.
 import copy
 
 from propertyestimator.utils import graph, utils
-from propertyestimator.utils.serialization import deserialize_quantity
 from propertyestimator.utils.utils import get_nested_attribute, set_nested_attribute
 from propertyestimator.workflow.decorators import protocol_input, MergeBehaviour
 from propertyestimator.workflow.schemas import ProtocolSchema
@@ -187,9 +186,6 @@ class BaseProtocol:
         for input_full_path in schema_value.inputs:
 
             value = copy.deepcopy(schema_value.inputs[input_full_path])
-
-            if isinstance(value, dict) and 'unit' in value and 'unitless_value' in value:
-                value = deserialize_quantity(value)
 
             input_path = ProtocolPath.from_string(input_full_path)
             self.set_value(input_path, value)


### PR DESCRIPTION
## Description
The aim of this PR is to switch over to using `pint` units. The goal is to remove a number of awkward behaviors, including

  - a `dimensionless` quantity losing its unit after scalar multiplication.
  - handle cases such as `(x * simtk.unit.joule) / (y * simtk.unit.calorie)` being dimensionless.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Add conversions between `simtk.unit.X` <-> `pint.X`
  - [x] Add lots of tests for the conversions.
  - [x] Replace most instances of simtk.unit
  - [x] Run regression tests.

## Status
- [x] Ready to go