### PR TITLE
MBAR Raises Exception on Not Enough Samples

### DIFF
--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -210,9 +210,6 @@ class PropertyCalculationLayer:
 
                 matches = [x for x in server_request.queued_properties if x.id == returned_output.property_id]
 
-                for match in matches:
-                    server_request.queued_properties.remove(match)
-
                 if len(matches) > 1:
                     raise ValueError(f'A property id ({returned_output.property_id}) conflict occurred.')
 
@@ -233,6 +230,12 @@ class PropertyCalculationLayer:
                                      'queue based calculation backends, but should be investigated.')
 
                     continue
+
+                if returned_output.exception is not None:
+                    continue
+
+                for match in matches:
+                    server_request.queued_properties.remove(match)
 
                 substance_id = returned_output.calculated_property.substance.identifier
 

--- a/propertyestimator/properties/dielectric.py
+++ b/propertyestimator/properties/dielectric.py
@@ -262,15 +262,20 @@ class ReweightDielectricConstant(reweighting.ReweightWithMBARProtocol):
         volumes = self._prepare_observables_array(self._reference_volumes)
 
         if self._bootstrap_uncertainties:
-            self._execute_with_bootstrapping(unit.dimensionless,
-                                             dipoles=dipole_moments,
-                                             dipoles_sqr=dipole_moments_sqr,
-                                             volumes=volumes)
+            error = self._execute_with_bootstrapping(unit.dimensionless,
+                                                     dipoles=dipole_moments,
+                                                     dipoles_sqr=dipole_moments_sqr,
+                                                     volumes=volumes)
         else:
 
             return PropertyEstimatorException(directory=directory,
                                               message='Dielectric constant can only be reweighted in conjunction '
                                                       'with bootstrapped uncertainties.')
+
+        if error is not None:
+
+            error.directory = directory
+            return error
 
         return self._get_output_dictionary()
 


### PR DESCRIPTION
## Description
This PR changes the default MBAR behaviour such that an exception is now raised if the required number of effective samples is not met. It also fixes a minor bug where if a layer raised an exception estimating a property, the property would not get correctly cascaded to the next layer to estimate.

## Status
- [x] Ready to go