### PR TITLE
Only Calculate RW Layer Gradients if MBAR Completes

### DIFF
--- a/propertyestimator/properties/density.py
+++ b/propertyestimator/properties/density.py
@@ -136,7 +136,10 @@ class Density(PhysicalProperty):
                                              coordinate_path,
                                              trajectory_path,
                                              'grad',
-                                             ProtocolPath('uncorrelated_values', density_calculation.id))
+                                             ProtocolPath('uncorrelated_values', density_calculation.id),
+                                             effective_sample_indices=ProtocolPath('effective_sample_indices',
+                                                                                   base_reweighting_protocols.
+                                                                                   mbar_protocol.id))
 
         schema = WorkflowSchema(property_type=Density.__name__)
         schema.id = '{}{}'.format(Density.__name__, 'Schema')

--- a/propertyestimator/properties/dielectric.py
+++ b/propertyestimator/properties/dielectric.py
@@ -20,7 +20,7 @@ from propertyestimator.utils import timeseries
 from propertyestimator.utils.exceptions import PropertyEstimatorException
 from propertyestimator.utils.quantities import EstimatedQuantity
 from propertyestimator.utils.statistics import bootstrap
-from propertyestimator.workflow import plugins
+from propertyestimator.workflow import plugins, WorkflowOptions
 from propertyestimator.workflow.decorators import protocol_input, protocol_output
 from propertyestimator.workflow.schemas import WorkflowSchema
 from propertyestimator.workflow.utils import ProtocolPath
@@ -429,6 +429,10 @@ class DielectricConstant(PhysicalProperty):
         mbar_protocol.bootstrap_uncertainties = True
         mbar_protocol.bootstrap_iterations = 200
 
+        # TODO: Implement a cleaner way to handle this.
+        if options.convergence_mode == WorkflowOptions.ConvergenceMode.NoChecks:
+            mbar_protocol.required_effective_samples = -1
+
         # Make a copy of the mbar reweighting schema to use for evaulating gradients by reweighting.
         mbar_template_schema = mbar_protocol.schema
 
@@ -454,7 +458,9 @@ class DielectricConstant(PhysicalProperty):
                                              coordinate_path,
                                              trajectory_path,
                                              'grad',
-                                             template_reweighting_schema=mbar_template_schema)
+                                             template_reweighting_schema=mbar_template_schema,
+                                             effective_sample_indices=ProtocolPath('effective_sample_indices',
+                                                                                   mbar_protocol.id))
 
         schema = WorkflowSchema(property_type=DielectricConstant.__name__)
         schema.id = '{}{}'.format(DielectricConstant.__name__, 'Schema')

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -819,7 +819,9 @@ class EnthalpyOfVaporization(PhysicalProperty):
                                              liquid_trajectory_path,
                                              'grad',
                                              ProtocolPath('uncorrelated_values', extract_liquid_energy.id),
-                                             id_prefix='liquid_')
+                                             id_prefix='liquid_',
+                                             effective_sample_indices=ProtocolPath('effective_sample_indices',
+                                                                                   liquid_protocols.mbar_protocol.id))
 
         # Set up the gas phase gradient calculations
         gas_coordinate_path = ProtocolPath('output_coordinate_path', gas_protocols.concatenate_trajectories.id)
@@ -833,7 +835,9 @@ class EnthalpyOfVaporization(PhysicalProperty):
                                              'grad',
                                              ProtocolPath('uncorrelated_values', extract_gas_energy.id),
                                              id_prefix='gas_',
-                                             enable_pbc=False)
+                                             enable_pbc=False,
+                                             effective_sample_indices=ProtocolPath('effective_sample_indices',
+                                                                                   gas_protocols.mbar_protocol.id))
 
         # Combine the gradients.
         combine_gradients = gradients.SubtractGradients('combine_gradients_$(grad)')

--- a/propertyestimator/protocols/gradients.py
+++ b/propertyestimator/protocols/gradients.py
@@ -88,6 +88,12 @@ class GradientReducedPotentials(BaseProtocol):
         system which only contains the parameter of interest.
         """
 
+    @protocol_input(list)
+    def effective_sample_indices(self):
+        """NOTE - this is currently a placeholder input ONLY, and
+        currently is not used for anything.
+        """
+
     @protocol_output(list)
     def reference_potential_paths(self):
         pass
@@ -135,6 +141,10 @@ class GradientReducedPotentials(BaseProtocol):
 
         self._reverse_parameter_value = None
         self._forward_parameter_value = None
+
+        # This is currently a placeholder variable ONLY
+        # and should not be used for anything.
+        self._effective_sample_indices = []
 
     def _build_reduced_system(self, original_force_field, topology, scale_amount=None):
         """Produces an OpenMM system containing only forces for the specified parameter,

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -385,7 +385,8 @@ def generate_gradient_protocol_group(reference_force_field_paths,
                                      perturbation_scale=1.0e-4,
                                      substance_source=None,
                                      id_prefix='',
-                                     enable_pbc=True):
+                                     enable_pbc=True,
+                                     effective_sample_indices=None):
     """Constructs a set of protocols which, when combined in a workflow schema,
     may be executed to reweight a set of existing data to estimate a particular
     property. The reweighted observable of interest will be calculated by
@@ -426,6 +427,10 @@ def generate_gradient_protocol_group(reference_force_field_paths,
     enable_pbc: bool
         If true, periodic boundary conditions are employed when recalculating
         the reduced potentials.
+    effective_sample_indices: ProtocolPath, optional
+        A placeholder variable which can be used to make the gradient protocols
+        dependant on an MBAR protcol to ensure gradients aren't calcuated when
+        the MBAR protocol failed due to insufficient samples.
 
     Returns
     -------
@@ -465,6 +470,9 @@ def generate_gradient_protocol_group(reference_force_field_paths,
 
     reduced_potentials.use_subset_of_force_field = True
     reduced_potentials.enable_pbc = enable_pbc
+
+    if effective_sample_indices is not None:
+        reduced_potentials.effective_sample_indices = effective_sample_indices
 
     # Set up the protocols which will actually reweight the value of the
     # observable to the forward and reverse states.


### PR DESCRIPTION
## Description
This PR now enforces that reweighting layer gradients are only calculated if MBAR was able to actually reweight the observable of interest. 

This is done for now via a placeholder variable which should in future be extended to ensure that gradients are only calculated using samples which contribute to the average observable for faster performance.

## Status
- [x] Ready to go