### PR TITLE
Added Platform Options to Simulation Protocols

### DIFF
--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -612,6 +612,15 @@ class EnthalpyOfVaporization(PhysicalProperty):
         gas_protocols.production_simulation.enable_pbc = False
         gas_protocols.production_simulation.save_rolling_statistics = False
 
+        # Due to a bizarre issue where the OMM Reference platform is
+        # the fastest at computing properties of a single molecule
+        # in vacuum, we enforce those inputs which will force the
+        # gas calculations to run on the Reference platform.
+        gas_protocols.equilibration_simulation.high_precision = True
+        gas_protocols.equilibration_simulation.allow_gpu_platforms = False
+        gas_protocols.production_simulation.high_precision = True
+        gas_protocols.production_simulation.allow_gpu_platforms = False
+
         # Combine the values to estimate the final energy of vaporization
         energy_of_vaporization = miscellaneous.SubtractValues('energy_of_vaporization')
         energy_of_vaporization.value_b = ProtocolPath('value', extract_gas_energy.id)


### PR DESCRIPTION
## Description
This PR aims to fix poor performance issues when simulating only a single molecule in the gas phase. Running using either the CPU or CUDA platforms is at least 10x slower than running using the Reference platform.

This PR exposed options in the `RunOpenMMSimulation` protocol to both disable running on GPUs, and to run in high precision (which forces the Reference platform when GPUs are not present or allowed).

## Status
- [x] Ready to go