### PR TITLE
All Replicator Id's In Children of Replicated Protocols

### DIFF
--- a/propertyestimator/properties/density.py
+++ b/propertyestimator/properties/density.py
@@ -77,7 +77,7 @@ class Density(PhysicalProperty):
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_density_template,
-                                             ProtocolPath('force_field_path', 'global'),
+                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_source,
                                              trajectory_source,
@@ -123,17 +123,20 @@ class Density(PhysicalProperty):
             The schema to follow when estimating this property.
         """
 
+        data_replicator_id = 'data_replicator'
+
         # The protocol which will be used to calculate the densities from
         # the existing data.
-        density_calculation = analysis.ExtractAverageStatistic('calc_density_$(data_repl)')
+        density_calculation = analysis.ExtractAverageStatistic(f'calc_density_$({data_replicator_id})')
         density_calculation.statistics_type = ObservableType.Density
 
-        reweight_density = reweighting.ReweightStatistics('reweight_density')
+        reweight_density = reweighting.ReweightStatistics(f'reweight_density')
         reweight_density.statistics_type = ObservableType.Density
 
         reweighting_protocols, data_replicator = generate_base_reweighting_protocols(density_calculation,
                                                                                      reweight_density,
-                                                                                     options)
+                                                                                     options,
+                                                                                     data_replicator_id)
 
         # Set up the gradient calculations
         coordinate_path = ProtocolPath('output_coordinate_path', reweighting_protocols.concatenate_trajectories.id)
@@ -141,13 +144,13 @@ class Density(PhysicalProperty):
 
         reweight_density_template = reweighting.ReweightStatistics('')
         reweight_density_template.statistics_type = ObservableType.Density
-        reweight_density_template.statistics_paths = [ProtocolPath('statistics_file_path',
-                                                                   reweighting_protocols.unpack_stored_data.id)]
+        reweight_density_template.statistics_paths = ProtocolPath('statistics_file_path',
+                                                                  reweighting_protocols.unpack_stored_data.id)
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_density_template,
-                                             [ProtocolPath('force_field_path',
-                                                           reweighting_protocols.unpack_stored_data.id)],
+                                             ProtocolPath('force_field_path',
+                                                          reweighting_protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_path,
                                              trajectory_path,

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -214,10 +214,8 @@ class EnthalpyOfMixing(PhysicalProperty):
             A reference to the value of the gradient.
         """
 
-        full_id_suffix = id_suffix
-
         if replicator_id is not None:
-            full_id_suffix = f'{id_suffix}_$({replicator_id})'
+            id_suffix = f'{id_suffix}_$({replicator_id})'
 
         if substance_reference is None:
             substance_reference = ProtocolPath('substance', 'global')
@@ -230,9 +228,7 @@ class EnthalpyOfMixing(PhysicalProperty):
         # Define the protocols which will run the simulation itself.
         simulation_protocols, value_source, output_to_store = generate_base_simulation_protocols(extract_enthalpy,
                                                                                                  options,
-                                                                                                 id_suffix,
-                                                                                                 replicator_id=
-                                                                                                 replicator_id)
+                                                                                                 id_suffix)
 
         number_of_molecules = ProtocolPath('final_number_of_molecules', simulation_protocols.build_coordinates.id)
 
@@ -288,8 +284,7 @@ class EnthalpyOfMixing(PhysicalProperty):
                                              statistics_source,
                                              replicator_id=gradient_replicator_id,
                                              substance_source=substance_reference,
-                                             id_suffix=id_suffix,
-                                             group_id_suffix=full_id_suffix)
+                                             id_suffix=id_suffix)
 
         if weight_by_mole_fraction:
 
@@ -689,7 +684,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         liquid_gradient_group, liquid_gradient_replicator, liquid_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             ProtocolPath('force_field_path', 'global'),
+                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              liquid_coordinate_source,
                                              liquid_trajectory_source,
@@ -705,7 +700,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         gas_gradient_group, gas_gradient_replicator, gas_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             ProtocolPath('force_field_path', 'global'),
+                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              gas_coordinate_source,
                                              gas_trajectory_source,
@@ -860,7 +855,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         liquid_gradient_group, liquid_gradient_replicator, liquid_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             [ProtocolPath('force_field_path', liquid_protocols.unpack_stored_data.id)],
+                                             ProtocolPath('force_field_path', liquid_protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              liquid_coordinate_path,
                                              liquid_trajectory_path,
@@ -876,7 +871,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
 
         gas_gradient_group, gas_gradient_replicator, gas_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             [ProtocolPath('force_field_path', gas_protocols.unpack_stored_data.id)],
+                                             ProtocolPath('force_field_path', gas_protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              gas_coordinate_path,
                                              gas_trajectory_path,

--- a/propertyestimator/protocols/gradients.py
+++ b/propertyestimator/protocols/gradients.py
@@ -327,7 +327,7 @@ class GradientReducedPotentials(BaseProtocol):
 
         if len(self._reference_force_field_paths) != 1 and self._use_subset_of_force_field:
 
-            return PropertyEstimatorException(directory, 'A single reference force field must be'
+            return PropertyEstimatorException(directory, 'A single reference force field must be '
                                                          'provided when calculating the reduced '
                                                          'potentials using a subset of the full force')
 

--- a/propertyestimator/protocols/groups.py
+++ b/propertyestimator/protocols/groups.py
@@ -603,9 +603,16 @@ class ProtocolGroup(BaseProtocol):
 
         return self._protocols[target_protocol_id].set_value(reference_path_clone, value)
 
-    def apply_replicator(self, replicator, template_values, update_input_references=False):
+    def apply_replicator(self, replicator, template_values, template_index=-1, template_value=None,
+                         update_input_references=False):
 
-        protocols, replication_map = replicator.apply(self.protocols, template_values)
+        protocols, replication_map = replicator.apply(self.protocols, template_values,
+                                                      template_index, template_value)
+
+        if (template_index >= 0 or template_value is not None) and update_input_references is True:
+
+            raise ValueError('Specific template indices and values cannot be passed '
+                             'when `update_input_references` is True')
 
         if update_input_references:
             replicator.update_references(protocols, replication_map, template_values)

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -2,7 +2,7 @@
 A set of utilities for setting up property estimation workflows.
 """
 import copy
-from collections import namedtuple, Iterable
+from collections import namedtuple
 
 from propertyestimator import unit
 from propertyestimator.protocols import analysis, forcefield, gradients, groups, reweighting, coordinates, simulation, \

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -106,8 +106,8 @@ def generate_base_reweighting_protocols(analysis_protocol, mbar_protocol, workfl
 
     # Stitch together all of the trajectories
     join_trajectories = reweighting.ConcatenateTrajectories('concat_traj' + id_suffix)
-    join_trajectories.input_coordinate_paths = [ProtocolPath('coordinate_file_path', unpack_stored_data.id)]
-    join_trajectories.input_trajectory_paths = [ProtocolPath('output_trajectory_path', decorrelate_trajectory.id)]
+    join_trajectories.input_coordinate_paths = ProtocolPath('coordinate_file_path', unpack_stored_data.id)
+    join_trajectories.input_trajectory_paths = ProtocolPath('output_trajectory_path', decorrelate_trajectory.id)
 
     # Calculate the reduced potentials for each of the reference states.
     build_reference_system = forcefield.BuildSmirnoffSystem('build_system{}'.format(replicator_suffix))
@@ -135,7 +135,7 @@ def generate_base_reweighting_protocols(analysis_protocol, mbar_protocol, workfl
     reduced_target_potential.trajectory_file_path = ProtocolPath('output_trajectory_path', join_trajectories.id)
 
     # Finally, apply MBAR to get the reweighted value.
-    mbar_protocol.reference_reduced_potentials = [ProtocolPath('statistics_file_path', reduced_reference_potential.id)]
+    mbar_protocol.reference_reduced_potentials = ProtocolPath('statistics_file_path', reduced_reference_potential.id)
     mbar_protocol.target_reduced_potentials = [ProtocolPath('statistics_file_path', reduced_target_potential.id)]
 
     if (isinstance(mbar_protocol, reweighting.ReweightStatistics) and
@@ -144,12 +144,12 @@ def generate_base_reweighting_protocols(analysis_protocol, mbar_protocol, workfl
         mbar_protocol.statistics_type != ObservableType.Enthalpy and
         mbar_protocol.statistics_type != ObservableType.ReducedPotential):
 
-        mbar_protocol.statistics_paths = [ProtocolPath('output_statistics_path', decorrelate_statistics.id)]
+        mbar_protocol.statistics_paths = ProtocolPath('output_statistics_path', decorrelate_statistics.id)
 
     elif isinstance(mbar_protocol, reweighting.ReweightStatistics):
 
         mbar_protocol.statistics_paths = [ProtocolPath('statistics_file_path', reduced_target_potential.id)]
-        mbar_protocol.frame_counts = [ProtocolPath('number_of_uncorrelated_samples', decorrelate_statistics.id)]
+        mbar_protocol.frame_counts = ProtocolPath('number_of_uncorrelated_samples', decorrelate_statistics.id)
 
     # TODO: Implement a cleaner way to handle this.
     if workflow_options.convergence_mode == WorkflowOptions.ConvergenceMode.NoChecks:
@@ -451,9 +451,6 @@ def generate_gradient_protocol_group(template_reweighting_protocol,
     # Set values of the optional parameters.
     substance_source = ProtocolPath('substance', 'global') if substance_source is None else substance_source
     effective_sample_indices = effective_sample_indices if effective_sample_indices is not None else []
-
-    if not isinstance(reference_force_field_paths, Iterable):
-        reference_force_field_paths = [reference_force_field_paths]
 
     # Define the protocol which will evaluate the reduced potentials of the
     # reference, forward and reverse states using only a subset of the full

--- a/propertyestimator/tests/test_workflow/test_replicators.py
+++ b/propertyestimator/tests/test_workflow/test_replicators.py
@@ -140,10 +140,10 @@ def test_advanced_group_replicators():
     dummy_replicated_protocol_2 = DummyEstimatedQuantityProtocol(f'dummy_2_$({replicator_id})')
     dummy_replicated_protocol_2.input_value = ReplicatorValue(replicator_id)
 
-    dummy_group_2 = ProtocolGroup('dummy_group_2')
+    dummy_group_2 = ProtocolGroup(f'dummy_group_2_$({replicator_id})')
     dummy_group_2.add_protocols(dummy_replicated_protocol_2)
 
-    dummy_group = ProtocolGroup('dummy_group')
+    dummy_group = ProtocolGroup(f'dummy_group_$({replicator_id})')
     dummy_group.add_protocols(dummy_replicated_protocol, dummy_group_2)
     dummy_schema.protocols[dummy_group.id] = dummy_group.schema
 
@@ -177,20 +177,23 @@ def test_advanced_group_replicators():
     dummy_workflow = Workflow(dummy_property, dummy_metadata, '')
     dummy_workflow.schema = dummy_schema
 
-    assert len(dummy_workflow.protocols) == 5
+    assert len(dummy_workflow.protocols) == 6
 
-    assert dummy_workflow.protocols[dummy_group.id].protocols['dummy_0'].input_value == replicator.template_values[0]
-    assert dummy_workflow.protocols[dummy_group.id].protocols['dummy_1'].input_value == replicator.template_values[1]
+    assert dummy_workflow.protocols['dummy_group_0'].protocols['dummy_0'].input_value == replicator.template_values[0]
+    assert 'dummy_1' not in dummy_workflow.protocols['dummy_group_0'].protocols
+
+    assert dummy_workflow.protocols['dummy_group_1'].protocols['dummy_1'].input_value == replicator.template_values[1]
+    assert 'dummy_0' not in dummy_workflow.protocols['dummy_group_1'].protocols
 
     assert dummy_workflow.protocols['dummy_single_0'].input_value == ProtocolPath('output_value',
-                                                                                  dummy_group.id, 'dummy_0')
+                                                                                  'dummy_group_0', 'dummy_0')
     assert dummy_workflow.protocols['dummy_single_1'].input_value == ProtocolPath('output_value',
-                                                                                  dummy_group.id, 'dummy_1')
+                                                                                  'dummy_group_1', 'dummy_1')
 
-    assert dummy_workflow.protocols['dummy_single_2_0'].input_value == ProtocolPath('output_value', dummy_group.id,
-                                                                                    dummy_group_2.id, 'dummy_2_0')
-    assert dummy_workflow.protocols['dummy_single_2_1'].input_value == ProtocolPath('output_value', dummy_group.id,
-                                                                                    dummy_group_2.id, 'dummy_2_1')
+    assert dummy_workflow.protocols['dummy_single_2_0'].input_value == ProtocolPath('output_value', 'dummy_group_0',
+                                                                                    'dummy_group_2_0', 'dummy_2_0')
+    assert dummy_workflow.protocols['dummy_single_2_1'].input_value == ProtocolPath('output_value', 'dummy_group_1',
+                                                                                    'dummy_group_2_1', 'dummy_2_1')
 
 
 def test_nested_replicators():

--- a/propertyestimator/workflow/protocols.py
+++ b/propertyestimator/workflow/protocols.py
@@ -517,7 +517,8 @@ class BaseProtocol:
 
         set_nested_attribute(self, reference_path.property_name, value)
 
-    def apply_replicator(self, replicator, template_values, update_input_references=False):
+    def apply_replicator(self, replicator, template_values, template_index=-1,
+                         template_value=None, update_input_references=False):
         """Applies a `ProtocolReplicator` to this protocol. This method
         should clone any protocols whose id contains the id of the
         replicator (in the format `$(replicator.id)`).
@@ -527,13 +528,40 @@ class BaseProtocol:
         replicator: ProtocolReplicator
             The replicator to apply.
         template_values: list of Any
-            The values to pass to each of the replicated protocols.
+            A list of the values which will be inserted
+            into the newly replicated protocols.
+
+            This parameter is mutually exclusive with
+            `template_index` and `template_value`
+        template_index: int, optional
+            A specific value which should be used for any
+            protocols flagged as to be replicated by the
+            replicator. This option is mainly used when
+            replicating children of an already replicated
+            protocol.
+
+            This parameter is mutually exclusive with
+            `template_values` and must be set along with
+            a `template_value`.
+        template_value: Any, optional
+            A specific index which should be used for any
+            protocols flagged as to be replicated by the
+            replicator. This option is mainly used when
+            replicating children of an already replicated
+            protocol.
+
+            This parameter is mutually exclusive with
+            `template_values` and must be set along with
+            a `template_index`.
         update_input_references: bool
             If true, any protocols which take their input from a protocol
             which was flagged for replication will be updated to take input
-            from the acutally replicated protocol. This should only be set
+            from the actually replicated protocol. This should only be set
             to true if this protocol is not nested within a workflow or a
             protocol group.
+
+            This option cannot be used when a specific `template_index` or
+            `template_value` is providied.
 
         Returns
         -------

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -390,6 +390,19 @@ class Workflow:
         # Replicate any outputs.
         self._apply_replicator_to_outputs(replicator, template_values)
 
+        for other_replicator in schema.replicators:
+
+            # Get the list of values which will be passed to the newly created protocols.
+            if (not isinstance(other_replicator.template_values, ProtocolPath) or
+                replicator.placeholder_id not in other_replicator.template_values.full_path):
+
+                continue
+
+            other_replicator.template_values = [
+                ProtocolPath.from_string(other_replicator.template_values.full_path.replace(
+                    replicator.placeholder_id, str(index))) for index in range(len(template_values))
+            ]
+
     def _apply_replicator_to_outputs(self, replicator, template_values):
 
         outputs_to_replicate = []

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -210,7 +210,7 @@ class Workflow:
 
         for label in schema.outputs_to_store:
             self._append_uuid_to_output_to_store(schema.outputs_to_store[label])
-            self.outputs_to_store = schema.outputs_to_store[label]
+            self.outputs_to_store[label] = schema.outputs_to_store[label]
 
         self._build_protocols(schema)
         self._build_dependants_graph()


### PR DESCRIPTION
## Description
This PR extends #82 to allow replicator ids in the ids of child protocols of those which have already been replicated. It also fixes a few minor bugs in the replicator code.

## Status
- [X] Ready to go