### PR TITLE
Fix for Replicators Redirecting Index XY to Index X

### DIFF
--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -441,7 +441,7 @@ def generate_gradient_protocol_group(template_reweighting_protocol,
 
     assert isinstance(template_reweighting_protocol, reweighting.BaseMBARProtocol)
 
-    id_suffix = f'{id_suffix}_$({replicator_id})'
+    id_suffix = f'_$({replicator_id}){id_suffix}'
 
     # Set values of the optional parameters.
     substance_source = ProtocolPath('substance', 'global') if substance_source is None else substance_source
@@ -509,7 +509,7 @@ def generate_gradient_protocol_group(template_reweighting_protocol,
     central_difference.forward_parameter_value = ProtocolPath('forward_parameter_value', reduced_potentials.id)
 
     # Assemble all of the protocols into a convenient group wrapper.
-    gradient_group = groups.ProtocolGroup(f'gradient_group_{id_suffix}')
+    gradient_group = groups.ProtocolGroup(f'gradient_group{id_suffix}')
     gradient_group.add_protocols(reduced_potentials, reverse_mbar, forward_mbar, central_difference)
 
     # Create the replicator which will copy the group for each parameter gradient

--- a/propertyestimator/workflow/schemas.py
+++ b/propertyestimator/workflow/schemas.py
@@ -324,7 +324,7 @@ class ProtocolReplicator(TypedBaseModel):
 
                         original_id, replicated_index = map_tuple
 
-                        if full_source_path.protocol_path.find(replicated_id.protocol_path) < 0:
+                        if full_source_path.protocol_path != replicated_id.protocol_path:
                             continue
 
                         value_source = ProtocolPath.from_string(value_reference.full_path.replace(


### PR DESCRIPTION
## Description
Replicators would incorrectly point the input source of protocols targeting replicated `replicated_protocol_id_XY` to `replicated_protocol_id_X`.

## Status
- [X] Ready to go