### PR TITLE
Allow Multiple Types of Amount Per Component

### DIFF
--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -71,12 +71,21 @@ class BaseWeightByMoleFraction(BaseProtocol):
         assert len(self._component.components) == 1
 
         main_component = self._component.components[0]
-        amount = self._full_substance.get_amount(main_component)
+        amounts = self._full_substance.get_amounts(main_component)
+
+        if len(amounts) != 1:
+
+            return PropertyEstimatorException(directory=directory,
+                                              message=f'More than one type of amount was defined for component '
+                                                      f'{main_component}. Only a single mole fraction must be '
+                                                      f'defined.')
+
+        amount = amounts[0]
 
         if not isinstance(amount, Substance.MoleFraction):
 
             return PropertyEstimatorException(directory=directory,
-                                              message=f'The component {main_component} was given in an '
+                                              message=f'The component {main_component} was given as an '
                                                       f'exact amount, and not a mole fraction')
 
         self._weighted_value = self._weight_values(amount.value)

--- a/propertyestimator/protocols/miscellaneous.py
+++ b/propertyestimator/protocols/miscellaneous.py
@@ -216,12 +216,14 @@ class FilterSubstanceByRole(BaseProtocol):
 
             filtered_components.append(component)
 
-            amount = self._input_substance.get_amount(component)
+            amounts = self._input_substance.get_amounts(component)
 
-            if not isinstance(amount, Substance.MoleFraction):
-                continue
+            for amount in amounts:
 
-            total_mole_fraction += amount.value
+                if not isinstance(amount, Substance.MoleFraction):
+                    continue
+
+                total_mole_fraction += amount.value
 
         if 0 <= self._expected_components != len(filtered_components):
 
@@ -236,11 +238,13 @@ class FilterSubstanceByRole(BaseProtocol):
 
         for component in filtered_components:
 
-            amount = self._input_substance.get_amount(component)
+            amounts = self._input_substance.get_amounts(component)
 
-            if isinstance(amount, Substance.MoleFraction):
-                amount = Substance.MoleFraction(amount.value * inverse_mole_fraction)
+            for amount in amounts:
 
-            self._filtered_substance.add_component(component, amount)
+                if isinstance(amount, Substance.MoleFraction):
+                    amount = Substance.MoleFraction(amount.value * inverse_mole_fraction)
+
+                self._filtered_substance.add_component(component, amount)
 
         return self._get_output_dictionary()

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -435,12 +435,14 @@ class Substance(TypedBaseModel):
 
         for index, component in enumerate(self._components):
 
-            amount = self._amounts[component.identifier]
+            amounts = self._amounts[component.identifier]
 
-            if not isinstance(amount, Substance.ExactAmount):
-                continue
+            for amount in amounts:
 
-            remaining_molecule_slots -= amount.value
+                if not isinstance(amount, Substance.ExactAmount):
+                    continue
+
+                remaining_molecule_slots -= amount.value
 
         if remaining_molecule_slots < 0:
 

--- a/propertyestimator/tests/test_substances.py
+++ b/propertyestimator/tests/test_substances.py
@@ -1,0 +1,49 @@
+"""
+Units tests for propertyestimator.substances
+"""
+import numpy as np
+
+from propertyestimator.substances import Substance
+
+
+def test_add_mole_fractions():
+
+    substance = Substance()
+
+    substance.add_component(Substance.Component('C'), Substance.MoleFraction(0.5))
+    substance.add_component(Substance.Component('C'), Substance.MoleFraction(0.5))
+
+    assert substance.number_of_components == 1
+
+    amounts = substance.get_amounts('C')
+
+    assert len(amounts) == 1
+    assert isinstance(amounts[0], Substance.MoleFraction)
+
+    assert np.isclose(amounts[0].value, 1.0)
+
+
+def test_multiple_amounts():
+
+    substance = Substance()
+
+    substance.add_component(Substance.Component('[Na+]'), Substance.MoleFraction(0.75))
+    substance.add_component(Substance.Component('[Na+]'), Substance.ExactAmount(1))
+
+    substance.add_component(Substance.Component('[Cl-]'), Substance.MoleFraction(0.25))
+    substance.add_component(Substance.Component('[Cl-]'), Substance.ExactAmount(1))
+
+    assert substance.number_of_components == 2
+
+    sodium_amounts = substance.get_amounts('[Na+]')
+    chlorine_amounts = substance.get_amounts('[Cl-]')
+
+    assert len(sodium_amounts) == 2
+    assert len(chlorine_amounts) == 2
+
+    molecule_counts = substance.get_molecules_per_component(6)
+
+    assert len(molecule_counts) == 2
+
+    assert molecule_counts['[Na+]'] == 4
+    assert molecule_counts['[Cl-]'] == 2

--- a/propertyestimator/tests/test_substances.py
+++ b/propertyestimator/tests/test_substances.py
@@ -18,9 +18,11 @@ def test_add_mole_fractions():
     amounts = substance.get_amounts('C')
 
     assert len(amounts) == 1
-    assert isinstance(amounts[0], Substance.MoleFraction)
 
-    assert np.isclose(amounts[0].value, 1.0)
+    amount = next(iter(amounts))
+
+    assert isinstance(amount, Substance.MoleFraction)
+    assert np.isclose(amount.value, 1.0)
 
 
 def test_multiple_amounts():

--- a/propertyestimator/utils/serialization.py
+++ b/propertyestimator/utils/serialization.py
@@ -270,6 +270,31 @@ def deserialize_set(set_dictionary):
     return set(set_value)
 
 
+def serialize_frozen_set(set_object):
+
+    if not isinstance(set_object, frozenset):
+        raise ValueError('{} is not a frozenset'.format(type(frozenset)))
+
+    return {
+        'value': list(set_object)
+    }
+
+
+def deserialize_frozen_set(set_dictionary):
+
+    if 'value' not in set_dictionary:
+
+        raise ValueError('The serialized frozenset dictionary must include'
+                         'the value of the set.')
+
+    set_value = set_dictionary['value']
+
+    if not isinstance(set_value, list):
+        raise ValueError('The value of the serialized set must be a list.')
+
+    return frozenset(set_value)
+
+
 class TypedJSONEncoder(json.JSONEncoder):
 
     _natively_supported_types = [
@@ -281,6 +306,7 @@ class TypedJSONEncoder(json.JSONEncoder):
         unit.Quantity: serialize_quantity,
         'ForceField': serialize_force_field,
         set: serialize_set,
+        frozenset: serialize_frozen_set,
         np.float16: lambda x: {'value': float(x)},
         np.float32: lambda x: {'value': float(x)},
         np.float64: lambda x: {'value': float(x)},
@@ -371,6 +397,7 @@ class TypedJSONDecoder(json.JSONDecoder):
         EstimatedQuantity: deserialize_estimated_quantity,
         'ForceField': deserialize_force_field,
         set: deserialize_set,
+        frozenset: deserialize_frozen_set,
         np.float16: lambda x: np.float16(x['value']),
         np.float32: lambda x: np.float32(x['value']),
         np.float64: lambda x: np.float64(x['value']),


### PR DESCRIPTION
## Description
This PR aims to allow substances to define multiple types of amount (e.g. mole fraction and an exact number of molecules) per component. This is useful when defining buffer solutions which contain ionic species in a specified mole fraction, while also defining counter ions in an exact number.

## Breaking Changes

This PR contains API breaking changes:

 - `Substance.get_amount` is now named `Substance.get_amounts` and returns an immutable `frozenset` of amounts, rather than a single amount.

## Status
- [X] Ready to go