### PR TITLE
Quick fix for Replicating Grouped Protocol

### DIFF
--- a/propertyestimator/workflow/schemas.py
+++ b/propertyestimator/workflow/schemas.py
@@ -188,6 +188,18 @@ class ProtocolReplicator(TypedBaseModel):
             if not should_replicate:
 
                 replicated_protocols[protocol_id] = protocol
+                
+                if template_index is not None and template_index >= 0:
+                    # Make sure to include children of replicated protocols in the
+                    # map to ensure correct behaviour when updating children of replicated
+                    # protocols which have the replicator id in their name, and take input
+                    # from another child protocol which doesn't have the replicator id in
+                    # its name.
+                    if ProtocolPath('', protocol_id) not in replicated_protocol_map:
+                        replicated_protocol_map[ProtocolPath('', protocol_id)] = []
+
+                    replicated_protocol_map[ProtocolPath('', protocol_id)].append(
+                        (ProtocolPath('', protocol_id), template_index))
 
                 self._apply_to_protocol_children(protocol, replicated_protocol_map,
                                                  template_values, template_index, template_value)


### PR DESCRIPTION
## Description
This PR aims to fix a bug which occurs when the child of a replicated protocol, which has the replicator id in it's id, takes input from another child of the replicated protocol, which doesn't have the replicator id in it's id.

Previously the child protocol would have it's input updated to take a list of values from all replicated instances of the other protocol. Now, the child protocol will take it's input from just the protocol in the same group (i.e. that has the same template index).

## Status
- [X] Ready to go