### PR TITLE
Add Missing Protocols To API Docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -349,6 +349,8 @@ Built-in Workflow Protocols
     MultiplyValue
     DivideValue
     FilterSubstanceByRole
+    BaseWeightByMoleFraction
+    WeightByMoleFraction
 
 Workflow Construction Utilities
 -------------------------------

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -27,11 +27,3 @@ Bugfixes
 -----------------------
 
 The initial pre-alpha release of the framework.
-
-* Replace the now removed protocols as follows
-    - ``DivideGradientByScalar`` -> ``DivideValue``
-    - ``MultiplyGradientByScalar`` -> ``MultiplyValue``
-    - ``AddGradients`` -> ``AddValues``
-    - ``SubtractGradients`` -> ``SubtractValues``
-    - ``WeightGradientByMoleFraction`` -> ``WeightByMoleFraction``
-    - ``WeightQuantityByMoleFraction`` -> ``WeightByMoleFraction``

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -27,3 +27,11 @@ Bugfixes
 -----------------------
 
 The initial pre-alpha release of the framework.
+
+* Replace the now removed protocols as follows
+    - ``DivideGradientByScalar`` -> ``DivideValue``
+    - ``MultiplyGradientByScalar`` -> ``MultiplyValue``
+    - ``AddGradients`` -> ``AddValues``
+    - ``SubtractGradients`` -> ``SubtractValues``
+    - ``WeightGradientByMoleFraction`` -> ``WeightByMoleFraction``
+    - ``WeightQuantityByMoleFraction`` -> ``WeightByMoleFraction``


### PR DESCRIPTION
## Description
This PR adds the missing ``BaseWeightByMoleFraction`` and ``WeightByMoleFraction`` entries to the API docs page.

## Status
- [X] Ready to go