### PR TITLE
Fix for Excess Properties using an Incorrect Uncertainty Target

### DIFF
--- a/propertyestimator/properties/density.py
+++ b/propertyestimator/properties/density.py
@@ -302,11 +302,17 @@ class ExcessMolarVolume(PhysicalProperty):
 
             value_source = ProtocolPath('weighted_value', conditional_group.id, weight_by_mole_fraction.id)
 
-        # Make sure the weighted value is being used in the conditional comparison.
-        if options.convergence_mode != WorkflowOptions.ConvergenceMode.NoChecks and weight_by_mole_fraction:
-            conditional_group.conditions[0].left_hand_value = ProtocolPath('weighted_value.uncertainty',
-                                                                           conditional_group.id,
-                                                                           weight_by_mole_fraction.id)
+        if options.convergence_mode != WorkflowOptions.ConvergenceMode.NoChecks:
+
+            # Make sure the convergence criteria is set to use the per component
+            # uncertainty target.
+            conditional_group.conditions[0].right_hand_value = ProtocolPath('per_component_uncertainty', 'global')
+
+            if weight_by_mole_fraction:
+                # Make sure the weighted uncertainty is being used in the conditional comparison.
+                conditional_group.conditions[0].left_hand_value = ProtocolPath('weighted_value.uncertainty',
+                                                                               conditional_group.id,
+                                                                               weight_by_mole_fraction.id)
 
         # Set up the gradient calculations
         reweight_molar_volume_template = reweighting.ReweightStatistics('')

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -152,12 +152,17 @@ class EnthalpyOfMixing(PhysicalProperty):
 
             value_source = ProtocolPath('weighted_value', conditional_group.id, weight_by_mole_fraction.id)
 
-        # Make sure the weighted value is being used in the conditional comparison.
-        if options.convergence_mode != WorkflowOptions.ConvergenceMode.NoChecks and weight_by_mole_fraction:
+        if options.convergence_mode != WorkflowOptions.ConvergenceMode.NoChecks:
 
-            conditional_group.conditions[0].left_hand_value = ProtocolPath('weighted_value.uncertainty',
-                                                                           conditional_group.id,
-                                                                           weight_by_mole_fraction.id)
+            # Make sure the convergence criteria is set to use the per component
+            # uncertainty target.
+            conditional_group.conditions[0].right_hand_value = ProtocolPath('per_component_uncertainty', 'global')
+
+            if weight_by_mole_fraction:
+                # Make sure the weighted uncertainty is being used in the conditional comparison.
+                conditional_group.conditions[0].left_hand_value = ProtocolPath('weighted_value.uncertainty',
+                                                                               conditional_group.id,
+                                                                               weight_by_mole_fraction.id)
 
         # Set up the gradient calculations
         reweight_enthalpy_template = reweighting.ReweightStatistics('')


### PR DESCRIPTION
## Description
This PR aims to fix a bug where the uncertainty of each value which contributes to an excess property was converged to within the total target uncertainty in the excess quantity, rather than the target of any one component.

This is a silent bug which manifests itself as the calculation completing successfully having met the target uncertainty criteria of the conditional group, but then failing to meet the criteria in `WorkflowGraph._gather_results`. Such properties would be returned in the `unsuccessful_properties` attribute of the results objects with no exceptions being raised.

## Status
- [X] Ready to go