### PR TITLE
Reduce Memory Usage of Trajectories

### DIFF
--- a/integration_tests/trajectory_subsampling/run.py
+++ b/integration_tests/trajectory_subsampling/run.py
@@ -1,0 +1,117 @@
+"""An integrated test to ensure that streamed subsampling of trajectories
+yields correct results relative to subsampling a trajectory fully loaded
+into memory.
+"""
+import logging
+import time
+
+import numpy as np
+
+from propertyestimator import unit
+from propertyestimator.backends import ComputeResources
+from propertyestimator.protocols.analysis import ExtractUncorrelatedTrajectoryData
+from propertyestimator.protocols.forcefield import BuildSmirnoffSystem
+from propertyestimator.protocols.simulation import RunOpenMMSimulation
+from propertyestimator.substances import Substance
+from propertyestimator.thermodynamics import ThermodynamicState
+from propertyestimator.utils import setup_timestamp_logging
+
+
+def generate_trajectories():
+    """Generates trajectories to subsample.
+    """
+
+    setup_timestamp_logging()
+
+    logger = logging.getLogger()
+
+    substance = Substance.from_components('C(C(C(C(C(F)(F)Br)(F)F)(F)F)(F)F)(C(C(C(F)(F)F)(F)F)(F)F)(F)F')
+
+    logger.info('Building system.')
+
+    build_system = BuildSmirnoffSystem('build_system')
+    build_system.coordinate_file_path = 'coords.pdb'
+    build_system.substance = substance
+    build_system.force_field_path = 'smirnoff99Frosst-1.1.0.offxml'
+    build_system.execute('', None)
+
+    logger.info('System built.')
+
+    production_simulation = RunOpenMMSimulation(f'production_simulation')
+    production_simulation.steps = 500
+    production_simulation.output_frequency = 1
+    production_simulation.timestep = 2.0 * unit.femtosecond
+    production_simulation.thermodynamic_state = ThermodynamicState(temperature=298.15*unit.kelvin,
+                                                                   pressure=1.0*unit.atmosphere)
+    production_simulation.input_coordinate_file = 'coords.pdb'
+    production_simulation.system_path = 'system.xml'
+
+    compute_resources = ComputeResources(number_of_threads=4)
+
+    logger.info(f'Simulation started.')
+    production_simulation_schema = production_simulation.schema
+    production_simulation.execute('', compute_resources)
+    production_simulation.schema = production_simulation_schema
+    logger.info(f'Simulation finished.')
+
+
+def subsample_trajectory_memory(output_name, equilibration_index=0, stride=5):
+    """Subsamples a trajectory by fully loading it into memory.
+    """
+
+    import mdtraj
+
+    trajectory = mdtraj.load_dcd(filename='trajectory.dcd', top='coords.pdb')
+    trajectory = trajectory[equilibration_index:]
+
+    uncorrelated_indices = [index for index in range(0, trajectory.n_frames, stride)]
+    uncorrelated_trajectory = trajectory[uncorrelated_indices]
+
+    uncorrelated_trajectory.save_dcd(output_name)
+
+
+def main():
+
+    import mdtraj
+    generate_trajectories()
+
+    subsample_inputs = [
+        (0, 1),
+        (0, 5),
+        (0, 10),
+        (1, 1),
+        (3, 5),
+        (9, 10)
+    ]
+
+    for equilibration_index, stride, in subsample_inputs:
+
+        start_time = time.perf_counter()
+        subsample_trajectory = ExtractUncorrelatedTrajectoryData('stream_subsample')
+        subsample_trajectory.input_coordinate_file = 'coords.pdb'
+        subsample_trajectory.input_trajectory_path = 'trajectory.dcd'
+        subsample_trajectory.equilibration_index = equilibration_index
+        subsample_trajectory.statistical_inefficiency = stride
+        subsample_trajectory.execute('', None)
+        protocol_total_time = (time.perf_counter() - start_time) * 1000
+
+        start_time = time.perf_counter()
+        subsample_trajectory_memory('memory.dcd', equilibration_index, stride)
+        memory_total_time = (time.perf_counter() - start_time) * 1000
+
+        print(f'Eq Index={equilibration_index} '
+              f'Stride={stride} '
+              f'Protocol Time={protocol_total_time}s '
+              f'Memory Time={memory_total_time}s')
+
+        stream_trajectory = mdtraj.load_dcd(filename=subsample_trajectory.output_trajectory_path, top='coords.pdb')
+        memory_trajectory = mdtraj.load_dcd(filename='memory.dcd', top='coords.pdb')
+
+        assert len(stream_trajectory) == len(memory_trajectory)
+        assert np.allclose(stream_trajectory.xyz, memory_trajectory.xyz)
+        assert np.allclose(stream_trajectory.unitcell_lengths, memory_trajectory.unitcell_lengths)
+        assert np.allclose(stream_trajectory.unitcell_angles, memory_trajectory.unitcell_angles)
+
+
+if __name__ == '__main__':
+    main()

--- a/propertyestimator/properties/dielectric.py
+++ b/propertyestimator/properties/dielectric.py
@@ -192,7 +192,9 @@ class ExtractAverageDielectric(analysis.AverageTrajectoryProperty):
         dipole_moments, self._equilibration_index, self._statistical_inefficiency = \
             timeseries.decorrelate_time_series(dipole_moments)
 
-        sample_indices = timeseries.get_uncorrelated_indices(len(volumes), self._statistical_inefficiency)
+        uncorrelated_length = len(volumes) - self._equilibration_index
+
+        sample_indices = timeseries.get_uncorrelated_indices(uncorrelated_length, self._statistical_inefficiency)
         sample_indices = [index + self._equilibration_index for index in sample_indices]
 
         volumes = volumes[sample_indices]

--- a/propertyestimator/protocols/analysis.py
+++ b/propertyestimator/protocols/analysis.py
@@ -329,7 +329,7 @@ class ExtractUncorrelatedTrajectoryData(ExtractUncorrelatedData):
         stride = timeseries.get_uncorrelated_stride(self._statistical_inefficiency)
         frame_count = 0
 
-        with DCDTrajectoryFile('trajectory.dcd', 'r') as input_file:
+        with DCDTrajectoryFile(self._input_trajectory_path, 'r') as input_file:
 
             # Skip the equilibration configurations.
             if self._equilibration_index > 0:

--- a/propertyestimator/protocols/analysis.py
+++ b/propertyestimator/protocols/analysis.py
@@ -116,19 +116,13 @@ class AverageTrajectoryProperty(AveragePropertyProtocol):
         self._input_coordinate_file = None
         self._trajectory_path = None
 
-        self.trajectory = None
-
     def execute(self, directory, available_resources):
-
-        import mdtraj
 
         if self._trajectory_path is None:
 
             return PropertyEstimatorException(directory=directory,
                                               message='The AverageTrajectoryProperty protocol '
                                                        'requires a previously calculated trajectory')
-
-        self.trajectory = mdtraj.load_dcd(filename=self._trajectory_path, top=self._input_coordinate_file)
 
         return self._get_output_dictionary()
 
@@ -279,9 +273,39 @@ class ExtractUncorrelatedTrajectoryData(ExtractUncorrelatedData):
 
         self._output_trajectory_path = None
 
+    @staticmethod
+    def _yield_frame(file, topology, stride):
+        """A generator which yields frames of a DCD trajectory.
+
+        Parameters
+        ----------
+        file: mdtraj.DCDTrajectoryFile
+            The file object being used to read the trajectory.
+        topology: mdtraj.Topology
+            The object which describes the topology of the trajectory.
+        stride
+            Only read every stride-th frame.
+
+        Returns
+        -------
+        mdtraj.Trajectory
+            A trajectory containing only a single frame.
+        """
+
+        while True:
+
+            frame = file.read_as_traj(topology, n_frames=1, stride=stride)
+
+            if len(frame) == 0:
+                return
+
+            yield frame
+
     def execute(self, directory, available_resources):
 
         import mdtraj
+        from mdtraj.formats.dcd import DCDTrajectoryFile
+        from mdtraj.utils import in_units_of
 
         logging.info('Subsampling trajectory: {}'.format(self.id))
 
@@ -291,16 +315,39 @@ class ExtractUncorrelatedTrajectoryData(ExtractUncorrelatedData):
                                               message='The ExtractUncorrelatedTrajectoryData protocol '
                                                        'requires a previously calculated trajectory')
 
-        trajectory = mdtraj.load_dcd(filename=self._input_trajectory_path, top=self._input_coordinate_file)
-        trajectory = trajectory[self._equilibration_index:]
-
-        uncorrelated_indices = timeseries.get_uncorrelated_indices(trajectory.n_frames, self._statistical_inefficiency)
-        uncorrelated_trajectory = trajectory[uncorrelated_indices]
-
+        # Set the output path.
         self._output_trajectory_path = path.join(directory, 'uncorrelated_trajectory.dcd')
-        uncorrelated_trajectory.save_dcd(self._output_trajectory_path)
 
-        self._number_of_uncorrelated_samples = len(uncorrelated_trajectory)
+        # Load in the trajectories topology.
+        topology = mdtraj.load_frame(self._input_coordinate_file, 0).topology
+        # Parse the internal mdtraj distance unit. While private access is undesirable,
+        # this is never publicly defined and I believe this route to be preferable
+        # over hard coding this unit.
+        base_distance_unit = mdtraj.Trajectory._distance_unit
+
+        # Determine the stride that needs to be taken to yield uncorrelated frames.
+        stride = timeseries.get_uncorrelated_stride(self._statistical_inefficiency)
+        frame_count = 0
+
+        with DCDTrajectoryFile('trajectory.dcd', 'r') as input_file:
+
+            # Skip the equilibration configurations.
+            if self._equilibration_index > 0:
+                input_file.seek(self._equilibration_index)
+
+            with DCDTrajectoryFile(self._output_trajectory_path, 'w') as output_file:
+
+                for frame in self._yield_frame(input_file, topology, stride):
+
+                    output_file.write(
+                        xyz=in_units_of(frame.xyz, base_distance_unit, output_file.distance_unit),
+                        cell_lengths=in_units_of(frame.unitcell_lengths, base_distance_unit, output_file.distance_unit),
+                        cell_angles=frame.unitcell_angles[0]
+                    )
+
+                    frame_count += 1
+
+        self._number_of_uncorrelated_samples = frame_count
 
         logging.info('Trajectory subsampled: {}'.format(self.id))
 

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -504,7 +504,6 @@ class RunOpenMMSimulation(BaseProtocol):
         integrator: simtk.openmm.Integrator
             The integrator to evolve the simulation with.
         """
-        import mdtraj
 
         # Build the reporters which we will use to report the state
         # of the simulation.
@@ -514,13 +513,28 @@ class RunOpenMMSimulation(BaseProtocol):
         with open(os.path.join(directory, 'input.pdb'), 'w+') as configuration_file:
             app.PDBFile.writeFile(input_pdb_file.topology, input_pdb_file.positions, configuration_file)
 
-        trajectory_file_object = open(self._temporary_trajectory_path, 'wb')
+        # Make a copy of the existing trajectory to append to if one already exists.
+        append_trajectory = False
+
+        if os.path.isfile(self._trajectory_file_path):
+
+            shutil.copyfile(self._trajectory_file_path, self._temporary_trajectory_path)
+            append_trajectory = True
+
+        elif os.path.isfile(self._temporary_trajectory_path):
+            os.unlink(self._temporary_trajectory_path)
+
+        if append_trajectory:
+            trajectory_file_object = open(self._temporary_trajectory_path, 'r+b')
+        else:
+            trajectory_file_object = open(self._temporary_trajectory_path, 'w+b')
+
         trajectory_dcd_object = app.DCDFile(trajectory_file_object,
                                             topology,
                                             integrator.getStepSize(),
                                             0,
                                             self._output_frequency,
-                                            False)
+                                            append_trajectory)
 
         expected_number_of_statistics = math.ceil(self.steps / self.output_frequency)
 
@@ -623,20 +637,7 @@ class RunOpenMMSimulation(BaseProtocol):
 
         # Move the trajectory and statistics files to their
         # final location.
-        if not os.path.isfile(self._trajectory_file_path):
-            os.replace(self._temporary_trajectory_path, self._trajectory_file_path)
-        else:
-            mdtraj_topology = mdtraj.Topology.from_openmm(topology)
-
-            existing_trajectory = mdtraj.load_dcd(self._trajectory_file_path, mdtraj_topology)
-            current_trajectory = mdtraj.load_dcd(self._temporary_trajectory_path, mdtraj_topology)
-
-            concatenated_trajectory = mdtraj.join([existing_trajectory,
-                                                   current_trajectory],
-                                                   check_topology=False,
-                                                   discard_overlapping_frames=False)
-
-            concatenated_trajectory.save_dcd(self._trajectory_file_path)
+        os.replace(self._temporary_trajectory_path, self._trajectory_file_path)
 
         if not os.path.isfile(self._statistics_file_path):
             os.replace(self._temporary_statistics_path, self._statistics_file_path)

--- a/propertyestimator/utils/timeseries.py
+++ b/propertyestimator/utils/timeseries.py
@@ -190,22 +190,41 @@ def decorrelate_time_series(time_series):
     return uncorrelated_time_series, equilibration_index, inefficiency
 
 
+def get_uncorrelated_stride(statistical_inefficiency):
+    """Returns the integer index stride between uncorrelated samples
+    in a time series.
+
+    Parameters
+    ----------
+    statistical_inefficiency: float
+        The statistical inefficiency of the time series.
+
+    Returns
+    -------
+    int
+        The integer index stride between uncorrelated samples
+        in a time series.
+    """
+    return int(math.ceil(statistical_inefficiency))
+
+
 def get_uncorrelated_indices(time_series_length, statistical_inefficiency):
-    """Returns the indices of the uncorrelated frames of a time series.
+    """Returns the indices of the uncorrelated frames of a time series,
+    taking strides according to `get_uncorrelated_stride`.
 
-        Parameters
-        ----------
-        time_series_length : int
-            The length of the time series to extract frames from.
-        statistical_inefficiency: float
-            The statistical inefficiency of the time series.
+    Parameters
+    ----------
+    time_series_length : int
+        The length of the time series to extract frames from.
+    statistical_inefficiency: float
+        The statistical inefficiency of the time series.
 
-        Returns
-        -------
-        list of int
-            The indices of the uncorrelated frames.
-        """
+    Returns
+    -------
+    list of int
+        The indices of the uncorrelated frames.
+    """
 
     # Extract a set of uncorrelated data points.
-    stride = int(math.ceil(statistical_inefficiency))
+    stride = get_uncorrelated_stride(statistical_inefficiency)
     return [index for index in range(0, time_series_length, stride)]


### PR DESCRIPTION
## Description
This PR aims to reduce the overall memory usage of protocols by handling trajectories in chunks, rather than loading the full things into memory.

Reweighting and gradient protocols will not be updated by this PR, but rather will be handled separately in a future dedicated PR.

## Status
- [X] Ready to go