### PR TITLE
Naive Workflow Protocol Replacements

### DIFF
--- a/propertyestimator/client.py
+++ b/propertyestimator/client.py
@@ -636,6 +636,12 @@ class PropertyEstimatorClient:
 
                 workflow = options.workflow_schemas[type_name][calculation_layer]
 
+                # Handle the cases where some protocol types should be replaced with
+                # others.
+                workflow.replace_protocol_types(
+                    options.workflow_options[type_name][calculation_layer].protocol_replacements
+                )
+
                 if workflow is None:
                     # Not all properties may support every calculation layer.
                     continue

--- a/propertyestimator/client.py
+++ b/propertyestimator/client.py
@@ -636,15 +636,15 @@ class PropertyEstimatorClient:
 
                 workflow = options.workflow_schemas[type_name][calculation_layer]
 
+                if workflow is None:
+                    # Not all properties may support every calculation layer.
+                    continue
+
                 # Handle the cases where some protocol types should be replaced with
                 # others.
                 workflow.replace_protocol_types(
                     options.workflow_options[type_name][calculation_layer].protocol_replacements
                 )
-
-                if workflow is None:
-                    # Not all properties may support every calculation layer.
-                    continue
 
                 # Will raise the correct exception for non-valid interfaces.
                 workflow.validate_interfaces()

--- a/propertyestimator/workflow/schemas.py
+++ b/propertyestimator/workflow/schemas.py
@@ -609,6 +609,36 @@ class WorkflowSchema(TypedBaseModel):
 
         return ProtocolPath.from_string(full_unreplicated_path)
 
+    def replace_protocol_types(self, protocol_replacements):
+        """Replaces protocols with given types with other protocols
+        of specified replacements. This is useful when replacing
+        the default protocols with custom ones, or swapping out base
+        protocols with actual implementations
+
+        Warnings
+        --------
+        This method is NOT fully implemented and is likely to fail in
+        all but a few specific cases. This method should be used with
+        extreme caution.
+
+        Parameters
+        ----------
+        protocol_replacements: dict of str and str, None
+            A dictionary with keys of the types of protocols which should be replaced
+            with those protocols named by the values.
+        """
+
+        if protocol_replacements is None:
+            return
+
+        self_json = self.json()
+
+        for key, value in protocol_replacements.items():
+            self_json.replace(key, value)
+
+        modified_schema = self.parse_json(self_json)
+        self.__setstate__(modified_schema.__getstate__())
+
     def _validate_replicators(self):
 
         for replicator in self.replicators:

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -55,7 +55,8 @@ class WorkflowOptions:
 
     def __init__(self,
                  convergence_mode=ConvergenceMode.RelativeUncertainty,
-                 relative_uncertainty_fraction=1.0, absolute_uncertainty=None):
+                 relative_uncertainty_fraction=1.0, absolute_uncertainty=None,
+                 protocol_replacements=None):
         """Constructs a new WorkflowOptions object.
 
         Parameters
@@ -73,6 +74,9 @@ class WorkflowOptions:
             If the convergence mode is set to `AbsoluteUncertainty`, then workflows
             will by default run simulations until the estimated uncertainty is less
             than the `absolute_uncertainty`
+        protocol_replacements: dict of str and str, optional
+            A dictionary with keys of the types of protocols which should be replaced
+            with those protocols named by the values.
         """
 
         self.convergence_mode = convergence_mode
@@ -92,13 +96,17 @@ class WorkflowOptions:
             raise ValueError('The absolute uncertainty must be set when the convergence '
                              'mode is set to AbsoluteUncertainty.')
 
+        self.protocol_replacements = protocol_replacements if protocol_replacements is not None else {}
+
     def __getstate__(self):
 
         return {
             'convergence_mode': self.convergence_mode,
 
             'absolute_uncertainty': self.absolute_uncertainty,
-            'relative_uncertainty_fraction': self.relative_uncertainty_fraction
+            'relative_uncertainty_fraction': self.relative_uncertainty_fraction,
+
+            'protocol_replacements': self.protocol_replacements
         }
 
     def __setstate__(self, state):
@@ -107,6 +115,8 @@ class WorkflowOptions:
 
         self.absolute_uncertainty = state['absolute_uncertainty']
         self.relative_uncertainty_fraction = state['relative_uncertainty_fraction']
+
+        self.protocol_replacements = state['protocol_replacements']
 
 
 class Workflow:


### PR DESCRIPTION
## Description
This method is a very naive first pass at adding the code neccessary to automatically replace certain protocols in workflows (such as `BuildSmirnoffSystem`) with others (such as `BuildTleapSystem`).

*This PR does not aim to fully implement this feature*, but rather just get a skeletal version working.

## Status
- [x] Ready to go