### PR TITLE
Fixes for Storing Substances with SMILES Containing Forward Slashes.

### DIFF
--- a/propertyestimator/storage/storage.py
+++ b/propertyestimator/storage/storage.py
@@ -9,6 +9,7 @@ from os import path
 from propertyestimator.forcefield import ForceFieldSource
 from propertyestimator.storage import StoredSimulationData
 from propertyestimator.storage.dataclasses import BaseStoredData
+from propertyestimator.utils.string import sanitize_smiles_file_name
 
 
 class PropertyEstimatorStorage:
@@ -395,7 +396,8 @@ class PropertyEstimatorStorage:
 
         if existing_data_key is None:
 
-            existing_data_key = "{}_{}".format(substance_id, uuid.uuid4())
+            sanitized_id = sanitize_smiles_file_name(substance_id)
+            existing_data_key = "{}_{}".format(sanitized_id, uuid.uuid4())
             data_to_store = data_object
 
         self._store_object(existing_data_key, data_to_store)

--- a/propertyestimator/tests/test_storage.py
+++ b/propertyestimator/tests/test_storage.py
@@ -53,9 +53,7 @@ def test_local_simulation_storage():
     """A simple test to that force fields can be stored and
     retrieved using the local storage backend."""
 
-    substance = Substance()
-    substance.add_component(Substance.Component(smiles='C'),
-                            Substance.MoleFraction())
+    substance = Substance.from_components(r'C', r'C/C=C/C=C/COC(=O)', r'CCOC(=O)/C=C(/C)\O')
 
     dummy_simulation_data = StoredSimulationData()
 

--- a/propertyestimator/tests/test_utils/test_string.py
+++ b/propertyestimator/tests/test_utils/test_string.py
@@ -1,9 +1,13 @@
 """
 Units tests for propertyestimator.utils.statistics
 """
+import tempfile
+from os import path
+
 import pytest
 
 from propertyestimator.utils import string
+from propertyestimator.utils.string import sanitize_smiles_file_name
 
 
 def test_valid_extract_variable_index_and_name():
@@ -32,3 +36,17 @@ def test_invalid_extract_variable_index_and_name(invalid_path):
 
     with pytest.raises(ValueError):
         string.extract_variable_index_and_name(invalid_path)
+
+
+@pytest.mark.parametrize('smiles_pattern', [r'C/C=C/C=C/COC(=O)', r'CCOC(=O)/C=C(/C)\O'])
+def test_sanitize_smiles_file_name(smiles_pattern):
+
+    smiles_file_name = f'file_{smiles_pattern}.json'
+    sanitized_smiles_file_name = sanitize_smiles_file_name(smiles_file_name)
+
+    assert sanitized_smiles_file_name.find('/') < 0
+
+    with tempfile.TemporaryDirectory() as temporary_directory:
+
+        with open(path.join(temporary_directory, sanitized_smiles_file_name), 'w') as file:
+            file.write(smiles_pattern)

--- a/propertyestimator/utils/string.py
+++ b/propertyestimator/utils/string.py
@@ -54,3 +54,20 @@ def extract_variable_index_and_name(string):
     property_name = string[0: start_bracket_index]
 
     return property_name, array_index
+
+
+def sanitize_smiles_file_name(file_name):
+    """Sanitizes a file name which contains smiles patterns.
+    Currently this method simply replaces any `/` characters
+    with a `_` character.
+
+    Parameters
+    ----------
+    file_name: str
+        The file name to sanitize
+
+    Returns
+    -------
+    The sanitized file name.
+    """
+    return file_name.replace('/', '_')

--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -19,7 +19,7 @@ from propertyestimator.storage.dataclasses import BaseStoredData, StoredSimulati
 from propertyestimator.utils import graph
 from propertyestimator.utils.exceptions import PropertyEstimatorException
 from propertyestimator.utils.serialization import TypedJSONEncoder, TypedJSONDecoder
-from propertyestimator.utils.string import extract_variable_index_and_name
+from propertyestimator.utils.string import extract_variable_index_and_name, sanitize_smiles_file_name
 from propertyestimator.utils.utils import SubhookedABCMeta, get_nested_attribute
 from propertyestimator.workflow.protocols import BaseProtocol
 from propertyestimator.workflow.schemas import WorkflowSchema, ProtocolReplicator, WorkflowSimulationDataToStore, \
@@ -1408,8 +1408,10 @@ class WorkflowGraph:
                                     output_to_store.substance is None else
                                     output_to_store.substance.identifier)
 
-                data_object_path = path.join(directory, f'results_{property_to_return.id}_{substance_id}.json')
-                data_directory = path.join(directory, f'results_{property_to_return.id}_{substance_id}')
+                sanitized_id = sanitize_smiles_file_name(substance_id)
+
+                data_object_path = path.join(directory, f'results_{property_to_return.id}_{sanitized_id}.json')
+                data_directory = path.join(directory, f'results_{property_to_return.id}_{sanitized_id}')
 
                 WorkflowGraph._store_output_data(data_object_path,
                                                  data_directory,


### PR DESCRIPTION
## Description
This PR fixes storing cached simulation data for substances which contain SMILES patterns which contain forward slashes (i.e. an illegal file path character).

## Status
- [X] Ready to go