### PR TITLE
Fix for Inconsistent Molecule Count Rounding

### DIFF
--- a/propertyestimator/protocols/coordinates.py
+++ b/propertyestimator/protocols/coordinates.py
@@ -246,11 +246,11 @@ class BuildCoordinatesPackmol(BaseProtocol):
 
         molecules, number_of_molecules, exception = self._build_molecule_arrays(directory)
 
-        self._output_number_of_molecules = sum(number_of_molecules)
-        self._output_substance = self._rebuild_substance(number_of_molecules)
-
         if exception is not None:
             return exception
+
+        self._output_number_of_molecules = sum(number_of_molecules)
+        self._output_substance = self._rebuild_substance(number_of_molecules)
 
         packmol_directory = path.join(directory, 'packmol_files')
 

--- a/propertyestimator/protocols/coordinates.py
+++ b/propertyestimator/protocols/coordinates.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from enum import Enum
 from os import path
 
+import numpy as np
 from simtk.openmm import app
 
 from propertyestimator import unit
@@ -186,6 +187,8 @@ class BuildCoordinatesPackmol(BaseProtocol):
             new_amounts[component].append(exact_amounts[0])
 
         # Recompute the mole fractions.
+        total_mole_fraction = 0.0
+
         for index, component in enumerate(self._substance.components):
 
             mole_fractions = [amount for amount in self._substance.get_amounts(component) if
@@ -199,7 +202,13 @@ class BuildCoordinatesPackmol(BaseProtocol):
             if component in new_amounts:
                 molecule_count -= new_amounts[component][0].value
 
-            new_amounts[component].append(Substance.MoleFraction(molecule_count / total_number_of_molecules))
+            new_mole_fraction = molecule_count / total_number_of_molecules
+            new_amounts[component].append(Substance.MoleFraction(new_mole_fraction))
+
+            total_mole_fraction += new_mole_fraction
+
+        if not np.isclose(total_mole_fraction, 1.0):
+            raise ValueError('The new mole fraction does not equal 1.0')
 
         output_substance = Substance()
 

--- a/propertyestimator/protocols/coordinates.py
+++ b/propertyestimator/protocols/coordinates.py
@@ -188,6 +188,7 @@ class BuildCoordinatesPackmol(BaseProtocol):
 
         # Recompute the mole fractions.
         total_mole_fraction = 0.0
+        number_of_new_mole_fractions = 0
 
         for index, component in enumerate(self._substance.components):
 
@@ -206,8 +207,9 @@ class BuildCoordinatesPackmol(BaseProtocol):
             new_amounts[component].append(Substance.MoleFraction(new_mole_fraction))
 
             total_mole_fraction += new_mole_fraction
+            number_of_new_mole_fractions += 1
 
-        if not np.isclose(total_mole_fraction, 1.0):
+        if not np.isclose(total_mole_fraction, 1.0) and number_of_new_mole_fractions > 0:
             raise ValueError('The new mole fraction does not equal 1.0')
 
         output_substance = Substance()

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -251,11 +251,10 @@ class Substance(TypedBaseModel):
             fractional_number_of_molecules = number_of_molecules % 1
 
             if np.isclose(fractional_number_of_molecules, 0.5):
-                fractional_number_of_molecules = 0
+                number_of_molecules = int(number_of_molecules)
             else:
-                fractional_number_of_molecules = int(round(fractional_number_of_molecules))
+                number_of_molecules = int(round(number_of_molecules))
 
-            number_of_molecules += fractional_number_of_molecules
             logging.info(f'{number_of_molecules}')
 
             if number_of_molecules == 0:

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -3,7 +3,6 @@ An API for defining and creating substances.
 """
 
 import abc
-import logging
 import math
 from enum import Enum
 

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -245,8 +245,6 @@ class Substance(TypedBaseModel):
         def to_number_of_molecules(self, total_substance_molecules, tolerance=None):
 
             # Determine how many molecules of each type will be present in the system.
-            logging.info(f'{self._value} {total_substance_molecules} {round(self._value * total_substance_molecules)}')
-
             number_of_molecules = self._value * total_substance_molecules
             fractional_number_of_molecules = number_of_molecules % 1
 
@@ -254,8 +252,6 @@ class Substance(TypedBaseModel):
                 number_of_molecules = int(number_of_molecules)
             else:
                 number_of_molecules = int(round(number_of_molecules))
-
-            logging.info(f'{number_of_molecules}')
 
             if number_of_molecules == 0:
                 raise ValueError('The total number of substance molecules was not large enough, '

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -3,6 +3,7 @@ An API for defining and creating substances.
 """
 
 import abc
+import logging
 import math
 from enum import Enum
 
@@ -244,7 +245,9 @@ class Substance(TypedBaseModel):
         def to_number_of_molecules(self, total_substance_molecules, tolerance=None):
 
             # Determine how many molecules of each type will be present in the system.
+            logging.info(f'{self._value} {total_substance_molecules} {round(self._value * total_substance_molecules)}')
             number_of_molecules = int(round(self._value * total_substance_molecules))
+            logging.info(f'{number_of_molecules}')
 
             if number_of_molecules == 0:
                 raise ValueError('The total number of substance molecules was not large enough, '

--- a/propertyestimator/substances.py
+++ b/propertyestimator/substances.py
@@ -246,7 +246,16 @@ class Substance(TypedBaseModel):
 
             # Determine how many molecules of each type will be present in the system.
             logging.info(f'{self._value} {total_substance_molecules} {round(self._value * total_substance_molecules)}')
-            number_of_molecules = int(round(self._value * total_substance_molecules))
+
+            number_of_molecules = self._value * total_substance_molecules
+            fractional_number_of_molecules = number_of_molecules % 1
+
+            if np.isclose(fractional_number_of_molecules, 0.5):
+                fractional_number_of_molecules = 0
+            else:
+                fractional_number_of_molecules = int(round(fractional_number_of_molecules))
+
+            number_of_molecules += fractional_number_of_molecules
             logging.info(f'{number_of_molecules}')
 
             if number_of_molecules == 0:


### PR DESCRIPTION
## Description
This PR aims to fix rounding inconsistencies when converting mole fractions into total number of molecules. 

An example of this is trying to convert a binary system with mole fractions of 0.7735 and 0.2265 into a system containing a maximum of 1000 molecules. Currently this would round to 774 and 227 molecules of each component respectively, yielding a total number of molecules greater than the maximum requested. Such edge cases are now rounded down to yield 773 and 226 molecules respectively.

## Status
- [X] Ready to go