### PR TITLE
Fix For Dask Merging Tasks by Key

### DIFF
--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -1118,8 +1118,7 @@ class WorkflowGraph:
                                                      workflow.gradients_sources,
                                                      workflow.outputs_to_store,
                                                      target_uncertainty,
-                                                     *final_futures,
-                                                     key=f'gather_{workflow.physical_property.id}'))
+                                                     *final_futures))
 
         return value_futures
 


### PR DESCRIPTION
## Description
This PR fixes a bug arising which seemingly arises from dask merging tasks with the same key, even if they have different arguments.

## Status
- [X] Ready to go