### PR TITLE
Remove An Unused Dask Keyword.

### DIFF
--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -145,9 +145,7 @@ class BaseDaskBackend(PropertyEstimatorBackend):
         self.stop()
 
     def start(self):
-
-        self._client = distributed.Client(self._cluster,
-                                          processes=False)
+        self._client = distributed.Client(self._cluster)
 
     def stop(self):
 


### PR DESCRIPTION
## Description
This PR is a quick fix for newer versions of dask which raises an exception when passing the unused `processes` kwarg to the `Client` object.

## Status
- [X] Ready to go