### PR TITLE
Simulation Protocol Well Defined Restarts

### DIFF
--- a/integration_tests/trajectory_subsampling/run.py
+++ b/integration_tests/trajectory_subsampling/run.py
@@ -38,7 +38,7 @@ def generate_trajectories():
     logger.info('System built.')
 
     production_simulation = RunOpenMMSimulation(f'production_simulation')
-    production_simulation.steps = 500
+    production_simulation.steps_per_iteration = 500
     production_simulation.output_frequency = 1
     production_simulation.timestep = 2.0 * unit.femtosecond
     production_simulation.thermodynamic_state = ThermodynamicState(temperature=298.15*unit.kelvin,

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -675,6 +675,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
         gas_protocols.production_simulation.ensemble = Ensemble.NVT
         gas_protocols.production_simulation.steps_per_iteration = 15000000
         gas_protocols.production_simulation.output_frequency = 5000
+        gas_protocols.production_simulation.checkpoint_frequency = 100
         gas_protocols.production_simulation.enable_pbc = False
         gas_protocols.production_simulation.save_rolling_statistics = False
 

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -671,13 +671,11 @@ class EnthalpyOfVaporization(PhysicalProperty):
         gas_protocols.energy_minimisation.enable_pbc = False
         gas_protocols.equilibration_simulation.ensemble = Ensemble.NVT
         gas_protocols.equilibration_simulation.enable_pbc = False
-        gas_protocols.equilibration_simulation.save_rolling_statistics = False
         gas_protocols.production_simulation.ensemble = Ensemble.NVT
         gas_protocols.production_simulation.steps_per_iteration = 15000000
         gas_protocols.production_simulation.output_frequency = 5000
         gas_protocols.production_simulation.checkpoint_frequency = 100
         gas_protocols.production_simulation.enable_pbc = False
-        gas_protocols.production_simulation.save_rolling_statistics = False
 
         # Due to a bizarre issue where the OMM Reference platform is
         # the fastest at computing properties of a single molecule

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -673,7 +673,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
         gas_protocols.equilibration_simulation.enable_pbc = False
         gas_protocols.equilibration_simulation.save_rolling_statistics = False
         gas_protocols.production_simulation.ensemble = Ensemble.NVT
-        gas_protocols.production_simulation.steps = 15000000
+        gas_protocols.production_simulation.steps_per_iteration = 15000000
         gas_protocols.production_simulation.output_frequency = 5000
         gas_protocols.production_simulation.enable_pbc = False
         gas_protocols.production_simulation.save_rolling_statistics = False
@@ -717,6 +717,12 @@ class EnthalpyOfVaporization(PhysicalProperty):
             condition.left_hand_value = ProtocolPath('result.uncertainty', converge_uncertainty.id,
                                                                            enthalpy_of_vaporization.id)
             condition.right_hand_value = ProtocolPath('target_uncertainty', 'global')
+
+            gas_protocols.production_simulation.number_of_iterations = ProtocolPath('current_iteration',
+                                                                                    converge_uncertainty.id)
+
+            liquid_protocols.production_simulation.number_of_iterations = ProtocolPath('current_iteration',
+                                                                                       converge_uncertainty.id)
 
             converge_uncertainty.add_condition(condition)
 

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -718,11 +718,11 @@ class EnthalpyOfVaporization(PhysicalProperty):
                                                                            enthalpy_of_vaporization.id)
             condition.right_hand_value = ProtocolPath('target_uncertainty', 'global')
 
-            gas_protocols.production_simulation.number_of_iterations = ProtocolPath('current_iteration',
-                                                                                    converge_uncertainty.id)
+            gas_protocols.production_simulation.total_number_of_iterations = ProtocolPath('current_iteration',
+                                                                                          converge_uncertainty.id)
 
-            liquid_protocols.production_simulation.number_of_iterations = ProtocolPath('current_iteration',
-                                                                                       converge_uncertainty.id)
+            liquid_protocols.production_simulation.total_number_of_iterations = ProtocolPath('current_iteration',
+                                                                                             converge_uncertainty.id)
 
             converge_uncertainty.add_condition(condition)
 

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -1,25 +1,27 @@
 """
 A collection of protocols for running molecular simulations.
 """
+import json
 import logging
-import math
+import io
 import os
-import shutil
+import re
 import traceback
 
-import numpy as np
+import pandas as pd
+
+from simtk import openmm, unit as simtk_unit
+from simtk.openmm import app
+
 from propertyestimator import unit
 from propertyestimator.thermodynamics import ThermodynamicState, Ensemble
 from propertyestimator.utils.exceptions import PropertyEstimatorException
-from propertyestimator.utils.openmm import setup_platform_with_resources, openmm_quantity_to_pint, \
-    pint_quantity_to_openmm, disable_pbc
-from propertyestimator.utils.statistics import StatisticsArray, ObservableType
-from propertyestimator.utils.utils import safe_unlink
+from propertyestimator.utils.openmm import setup_platform_with_resources, pint_quantity_to_openmm, disable_pbc
+from propertyestimator.utils.serialization import TypedJSONEncoder, TypedJSONDecoder
+from propertyestimator.utils.statistics import StatisticsArray
 from propertyestimator.workflow.decorators import protocol_input, protocol_output, InequalityMergeBehaviour, UNDEFINED
 from propertyestimator.workflow.plugins import register_calculation_protocol
 from propertyestimator.workflow.protocols import BaseProtocol
-from simtk import openmm, unit as simtk_unit
-from simtk.openmm import app
 
 
 @register_calculation_protocol()
@@ -116,12 +118,75 @@ class RunOpenMMSimulation(BaseProtocol):
     """Performs a molecular dynamics simulation in a given ensemble using
     an OpenMM backend.
     """
+    class _Checkpoint:
+        """A temporary checkpoint file which keeps track
+        of the parts of the simulation state not stored in
+        the checkpoint state xml file.
+        """
 
-    steps = protocol_input(
-        docstring='The number of timesteps to evolve the system by.',
+        def __init__(self, output_frequency=-1, checkpoint_frequency=-1, current_step_number=0):
+            self.output_frequency = output_frequency
+            self.checkpoint_frequency = checkpoint_frequency
+            self.current_step_number = current_step_number
+
+        def __getstate__(self):
+            return {
+                'output_frequency': self.output_frequency,
+                'checkpoint_frequency': self.checkpoint_frequency,
+                'current_step_number': self.current_step_number
+            }
+
+        def __setstate__(self, state):
+            self.output_frequency = state['output_frequency']
+            self.checkpoint_frequency = state['checkpoint_frequency']
+            self.current_step_number = state['current_step_number']
+
+    class _Simulation:
+        """A fake simulation class to use with the
+        openmm file reporters.
+        """
+
+        def __init__(self, integrator, topology, system, current_step):
+            self.integrator = integrator
+            self.topology = topology
+            self.system = system
+            self.currentStep = current_step
+
+    steps_per_iteration = protocol_input(
+        docstring='The number of steps to propogate the system by at '
+                  'each iteration. The total number of steps performed '
+                  'by this protocol will be `number_of_iterations * '
+                  'steps_per_iteration`.',
         type_hint=int, merge_behavior=InequalityMergeBehaviour.LargestValue,
         default_value=1000000
     )
+    number_of_iterations = protocol_input(
+        docstring='The number of times to propogate the system forward by the '
+                  '`steps_per_iteration` number of steps. The total number of '
+                  'steps performed by this protocol will be `number_of_iterations * '
+                  'steps_per_iteration`.',
+        type_hint=int, merge_behavior=InequalityMergeBehaviour.LargestValue,
+        default_value=1
+    )
+
+    output_frequency = protocol_input(
+        docstring='The frequency (in number of steps) with which to write to the '
+                  'output statistics and trajectory files.',
+        type_hint=int,
+        merge_behavior=InequalityMergeBehaviour.SmallestValue,
+        default_value=3000
+    )
+    checkpoint_frequency = protocol_input(
+        docstring='The frequency (in multiples of `output_frequency`) with which to '
+                  'write to a checkpoint file, e.g. if `output_frequency=100` and '
+                  '`checkpoint_frequency==2`, a checkpoint file would be saved every '
+                  '200 steps.',
+        type_hint=int,
+        merge_behavior=InequalityMergeBehaviour.SmallestValue,
+        optional=True,
+        default_value=10
+    )
+
     timestep = protocol_input(
         docstring='The timestep to evolve the system by at each step.',
         type_hint=unit.Quantity, merge_behavior=InequalityMergeBehaviour.SmallestValue,
@@ -145,13 +210,6 @@ class RunOpenMMSimulation(BaseProtocol):
         default_value=1.0 / unit.picoseconds
     )
 
-    output_frequency = protocol_input(
-        docstring='The frequency with which to write to the output statistics and '
-                  'trajectory files.',
-        type_hint=int, merge_behavior=InequalityMergeBehaviour.SmallestValue,
-        default_value=3000
-    )
-
     input_coordinate_file = protocol_input(
         docstring='The file path to the starting coordinates.',
         type_hint=str,
@@ -166,14 +224,6 @@ class RunOpenMMSimulation(BaseProtocol):
 
     enable_pbc = protocol_input(
         docstring='If true, periodic boundary conditions will be enabled.',
-        type_hint=bool,
-        default_value=True
-    )
-
-    save_rolling_statistics = protocol_input(
-        docstring='If True, the statistics file will be written to every '
-                  '`output_frequency` number of steps, rather than just once at '
-                  'the end of the simulation.',
         type_hint=bool,
         default_value=True
     )
@@ -209,10 +259,11 @@ class RunOpenMMSimulation(BaseProtocol):
 
         super().__init__(protocol_id)
 
-        self._temporary_statistics_path = None
-        self._temporary_trajectory_path = None
-
         self._checkpoint_path = None
+        self._state_path = None
+
+        self._local_trajectory_path = None
+        self._local_statistics_path = None
 
         self._context = None
         self._integrator = None
@@ -221,8 +272,9 @@ class RunOpenMMSimulation(BaseProtocol):
 
         # We handle most things in OMM units here.
         temperature = pint_quantity_to_openmm(self.thermodynamic_state.temperature)
-        pressure = pint_quantity_to_openmm(None if self.ensemble == Ensemble.NVT else
-                                           self.thermodynamic_state.pressure)
+
+        pressure = None if self.ensemble == Ensemble.NVT else self.thermodynamic_state.pressure
+        openmm_pressure = pint_quantity_to_openmm(pressure)
 
         if temperature is None:
 
@@ -230,7 +282,7 @@ class RunOpenMMSimulation(BaseProtocol):
                                               message='A temperature must be set to perform '
                                                       'a simulation in any ensemble')
 
-        if Ensemble(self.ensemble) == Ensemble.NPT and pressure is None:
+        if Ensemble(self.ensemble) == Ensemble.NPT and openmm_pressure is None:
 
             return PropertyEstimatorException(directory=directory,
                                               message='A pressure must be set to perform an NPT simulation')
@@ -242,28 +294,40 @@ class RunOpenMMSimulation(BaseProtocol):
 
         logging.info('Performing a simulation in the ' + str(self.ensemble) + ' ensemble: ' + self.id)
 
-        # Clean up any temporary files from previous (possibly failed)
-        # simulations.
-        self._temporary_statistics_path = os.path.join(directory, 'temp_statistics.csv')
-        self._temporary_trajectory_path = os.path.join(directory, 'temp_trajectory.dcd')
+        # Set up the internal file paths
+        self._checkpoint_path = os.path.join(directory, 'checkpoint.json')
+        self._state_path = os.path.join(directory, 'checkpoint_state.xml')
 
-        safe_unlink(self._temporary_statistics_path)
-        safe_unlink(self._temporary_trajectory_path)
-
-        self._checkpoint_path = os.path.join(directory, 'checkpoint.xml')
-
-        # Set up the output file paths
-        self.trajectory_file_path = os.path.join(directory, 'trajectory.dcd')
-        self.statistics_file_path = os.path.join(directory, 'statistics.csv')
+        self._local_trajectory_path = os.path.join(directory, 'trajectory.dcd')
+        self._local_statistics_path = os.path.join(directory, 'openmm_statistics.csv')
 
         # Set up the simulation objects.
         if self._context is None or self._integrator is None:
 
             self._context, self._integrator = self._setup_simulation_objects(temperature,
-                                                                             pressure,
+                                                                             openmm_pressure,
                                                                              available_resources)
 
-        result = self._simulate(directory, temperature, pressure, self._context, self._integrator)
+        # Save a copy of the starting configuration if it doesn't already exist
+        local_input_coordinate_path = os.path.join(directory, 'input.pdb')
+
+        if not os.path.isfile(local_input_coordinate_path):
+
+            input_pdb_file = app.PDBFile(self.input_coordinate_file)
+
+            with open(local_input_coordinate_path, 'w+') as configuration_file:
+                app.PDBFile.writeFile(input_pdb_file.topology, input_pdb_file.positions, configuration_file)
+
+        # Run the simulation.
+        result = self._simulate(directory, self._context, self._integrator)
+
+        # Set the output results.
+        self.trajectory_file_path = self._local_trajectory_path
+        self.statistics_file_path = os.path.join(directory, 'statistics.csv')
+
+        statistics = StatisticsArray.from_openmm_csv(self._local_statistics_path, pressure)
+        statistics.to_pandas_csv(self.statistics_file_path)
+
         return result
 
     def _setup_simulation_objects(self, temperature, pressure, available_resources):
@@ -365,84 +429,125 @@ class RunOpenMMSimulation(BaseProtocol):
 
         return context, integrator
 
-    def _write_statistics_array(self, raw_statistics, current_step, temperature, pressure,
-                                degrees_of_freedom, total_mass):
-        """Appends a set of statistics to an existing `statistics_array`.
-        Those statistics are potential energy, kinetic energy, total energy,
-        volume, density and reduced potential.
+    def _write_checkpoint_file(self, current_step_number, context):
+        """Writes a simulation checkpoint file to disk.
 
         Parameters
         ----------
-        raw_statistics: dict of ObservableType and numpy.ndarray
-            A dictionary of potential energies (kJ/mol), kinetic
-            energies (kJ/mol) and volumes (angstrom**3).
-        current_step: int
-            The index of the current step.
-        temperature: simtk.unit.Quantity
-            The temperature the system is being simulated at.
-        pressure: simtk.unit.Quantity
-            The pressure the system is being simulated at.
-        degrees_of_freedom: int
-            The number of degrees of freedom the system has.
-        total_mass: simtk.unit.Quantity
-            The total mass of the system.
+        current_step_number: int
+            The total number of steps which have been taken so
+            far.
+        context: simtk.openmm.Context
+            The current OpenMM context.
+        """
+
+        # Write the current state to disk
+        state = context.getState(getPositions=True,
+                                 getEnergy=True,
+                                 getVelocities=True,
+                                 getForces=True,
+                                 getParameters=True,
+                                 enforcePeriodicBox=self.enable_pbc)
+
+        with open(self._state_path, 'w') as file:
+            file.write(openmm.XmlSerializer.serialize(state))
+
+        checkpoint = self._Checkpoint(self.output_frequency, self.checkpoint_frequency, current_step_number)
+
+        with open(self._checkpoint_path, 'w') as file:
+            json.dump(checkpoint, file, cls=TypedJSONEncoder)
+
+    def _resume_from_checkpoint(self, context):
+        """Resumes the simulation from a checkpoint file.
+
+        Parameters
+        ----------
+        context: simtk.openmm.Context
+            The current OpenMM context.
 
         Returns
         -------
-        StatisticsArray
-            The statistics array with statistics appended.
+        int
+            The current step number.
         """
-        temperature = openmm_quantity_to_pint(temperature)
-        pressure = openmm_quantity_to_pint(pressure)
+        import mdtraj
 
-        beta = 1.0 / (unit.boltzmann_constant * temperature)
+        current_step_number = 0
 
-        raw_potential_energies = raw_statistics[ObservableType.PotentialEnergy][0:current_step + 1]
-        raw_kinetic_energies = raw_statistics[ObservableType.KineticEnergy][0:current_step + 1]
-        raw_volumes = raw_statistics[ObservableType.Volume][0:current_step + 1]
+        # Check whether the checkpoint files actually exists.
+        if (not os.path.isfile(self._checkpoint_path) or
+            not os.path.isfile(self._state_path)):
 
-        potential_energies = raw_potential_energies * unit.kilojoules / unit.mole
-        kinetic_energies = raw_kinetic_energies * unit.kilojoules / unit.mole
-        volumes = raw_volumes * unit.angstrom ** 3
+            logging.info('No checkpoint files were found.')
+            return current_step_number
 
-        # Calculate the instantaneous temperature, taking account the
-        # systems degrees of freedom.
-        temperatures = 2.0 * kinetic_energies / (degrees_of_freedom * unit.molar_gas_constant)
+        if (not os.path.isfile(self._local_statistics_path) or
+            not os.path.isfile(self._local_trajectory_path)):
 
-        # Calculate the systems enthalpy and reduced potential.
-        total_energies = potential_energies + kinetic_energies
-        enthalpies = None
+            raise ValueError('Checkpoint files were correctly found, but the trajectory '
+                             'or statistics files seem to be missing. This should not happen.')
 
-        reduced_potentials = potential_energies / unit.avogadro_number
+        # If they do, load the current state from disk.
+        with open(self._state_path, 'r') as file:
+            current_state = openmm.XmlSerializer.deserialize(file.read())
 
-        if pressure is not None:
+        with open(self._checkpoint_path, 'r') as file:
+            checkpoint = json.load(file, cls=TypedJSONDecoder)
 
-            pv_terms = pressure * volumes
+        if (self.output_frequency != checkpoint.output_frequency or
+            self.checkpoint_frequency != checkpoint.checkpoint_frequency):
 
-            reduced_potentials += pv_terms
-            enthalpies = total_energies + pv_terms * unit.avogadro_number
+            raise ValueError('Neither the output frequency nor the checkpoint '
+                             'frequency can currently be changed during the '
+                             'course of the simulation.')
 
-        reduced_potentials = (beta * reduced_potentials) * unit.dimensionless
+        context.setState(current_state)
 
-        # Calculate the systems density.
-        densities = total_mass / (volumes * unit.avogadro_number)
+        # Make sure that the number of frames in the trajectory /
+        # statistics file correspond to the recorded number of steps.
+        # This is to handle possible cases where only some of the files
+        # have been written from the current step (i.e only the trajectory may
+        # have been written to before this protocol gets unexpectedly killed.
+        expected_number_of_frames = int(checkpoint.current_step_number / self.output_frequency)
 
-        statistics_array = StatisticsArray()
+        # Handle the truncation of the statistics file.
+        with open(self._local_statistics_path) as file:
 
-        statistics_array[ObservableType.PotentialEnergy] = potential_energies
-        statistics_array[ObservableType.KineticEnergy] = kinetic_energies
-        statistics_array[ObservableType.TotalEnergy] = total_energies
-        statistics_array[ObservableType.Temperature] = temperatures
-        statistics_array[ObservableType.Volume] = volumes
-        statistics_array[ObservableType.Density] = densities
-        statistics_array[ObservableType.ReducedPotential] = reduced_potentials
+            header_line = file.readline()
+            file_contents = re.sub('#.*\n', '', file.read())
 
-        if enthalpies is not None:
-            statistics_array[ObservableType.Enthalpy] = enthalpies
+            with io.StringIO(file_contents) as string_object:
+                existing_statistics_array = pd.read_csv(string_object, index_col=False, header=None)
 
-        statistics_array.to_pandas_csv(self._temporary_statistics_path)
+        if len(existing_statistics_array) != expected_number_of_frames:
 
-    def _simulate(self, directory, temperature, pressure, context, integrator):
+            truncated_statistics_array = existing_statistics_array[0:expected_number_of_frames]
+
+            with open(self._local_statistics_path, 'w') as file:
+
+                file.write(f'{header_line}')
+                truncated_statistics_array.to_csv(file, index=False, header=False)
+
+        # Handle the truncation of the trajectory file.
+        trajectory_length = 0
+
+        for chunk in mdtraj.iterload(self._local_trajectory_path, top=self.input_coordinate_file):
+            trajectory_length += len(chunk)
+
+        if trajectory_length != expected_number_of_frames:
+
+            # TODO: Don't load the full trajectory into memory.
+            full_trajectory = mdtraj.load(self._local_trajectory_path, top=self.input_coordinate_file)
+            full_trajectory[0:expected_number_of_frames].save_dcd(self._local_trajectory_path)
+
+        new_trajectory_length = 0
+
+        for chunk in mdtraj.iterload(self._local_trajectory_path, top=self.input_coordinate_file):
+            new_trajectory_length += len(chunk)
+
+        return checkpoint.current_step_number
+
+    def _simulate(self, directory, context, integrator):
         """Performs the simulation using a given context
         and integrator.
 
@@ -450,87 +555,54 @@ class RunOpenMMSimulation(BaseProtocol):
         ----------
         directory: str
             The directory the trajectory is being run in.
-        temperature: simtk.unit.Quantity
-            The temperature to run the simulation at.
-        pressure: simtk.unit.Quantity
-            The pressure to run the simulation at.
         context: simtk.openmm.Context
             The OpenMM context to run with.
         integrator: simtk.openmm.Integrator
             The integrator to evolve the simulation with.
         """
 
+        # Define how many steps should be taken.
+        total_number_of_steps = self.number_of_iterations * self.steps_per_iteration
+
+        # Try to load the current state from any available checkpoint information
+        current_step = self._resume_from_checkpoint(context)
+
         # Build the reporters which we will use to report the state
         # of the simulation.
-        input_pdb_file = app.PDBFile(self.input_coordinate_file)
-        topology = input_pdb_file.topology
+        append_trajectory = os.path.isfile(self._local_trajectory_path)
+        dcd_reporter = app.DCDReporter(self._local_trajectory_path, 0, append_trajectory)
 
-        with open(os.path.join(directory, 'input.pdb'), 'w+') as configuration_file:
-            app.PDBFile.writeFile(input_pdb_file.topology, input_pdb_file.positions, configuration_file)
+        statistics_file = open(self._local_statistics_path, 'a+')
 
-        # Make a copy of the existing trajectory to append to if one already exists.
-        append_trajectory = False
+        statistics_reporter = app.StateDataReporter(statistics_file, 0,
+                                                    step=True,
+                                                    potentialEnergy=True,
+                                                    kineticEnergy=True,
+                                                    totalEnergy=True,
+                                                    temperature=True,
+                                                    volume=True,
+                                                    density=True)
 
-        if os.path.isfile(self.trajectory_file_path):
+        # Create the object which will transfer simulation output to the
+        # reporters.
+        topology = app.PDBFile(self.input_coordinate_file).topology
 
-            shutil.copyfile(self.trajectory_file_path, self._temporary_trajectory_path)
-            append_trajectory = True
+        with open(self.system_path, 'r') as file:
+            system = openmm.XmlSerializer.deserialize(file.read())
 
-        elif os.path.isfile(self._temporary_trajectory_path):
-            os.unlink(self._temporary_trajectory_path)
-
-        if append_trajectory:
-            trajectory_file_object = open(self._temporary_trajectory_path, 'r+b')
-        else:
-            trajectory_file_object = open(self._temporary_trajectory_path, 'w+b')
-
-        trajectory_dcd_object = app.DCDFile(trajectory_file_object,
-                                            topology,
-                                            integrator.getStepSize(),
-                                            0,
-                                            self.output_frequency,
-                                            append_trajectory)
-
-        expected_number_of_statistics = math.ceil(self.steps / self.output_frequency)
-
-        raw_statistics = {
-            ObservableType.PotentialEnergy: np.zeros(expected_number_of_statistics),
-            ObservableType.KineticEnergy: np.zeros(expected_number_of_statistics),
-            ObservableType.Volume: np.zeros(expected_number_of_statistics),
-        }
-
-        # Define any constants needed for extracting system statistics
-        # Compute the instantaneous temperature of degrees of freedom.
-        # This snipped is taken from the build in OpenMM `StateDataReporter`
-        system = context.getSystem()
-
-        degrees_of_freedom = sum([3 for i in range(system.getNumParticles()) if
-                                  system.getParticleMass(i) > 0 * simtk_unit.dalton])
-
-        degrees_of_freedom -= system.getNumConstraints()
-
-        if any(type(system.getForce(i)) == openmm.CMMotionRemover for i in range(system.getNumForces())):
-            degrees_of_freedom -= 3
-
-        total_mass = 0.0 * simtk_unit.dalton
-
-        for i in range(system.getNumParticles()):
-            total_mass += system.getParticleMass(i)
-
-        total_mass = openmm_quantity_to_pint(total_mass)
+        simulation = self._Simulation(integrator, topology, system, current_step)
 
         # Perform the simulation.
-        current_step_count = 0
-        current_step = 0
-
-        result = None
+        checkpoint_counter = 0
 
         try:
 
-            while current_step_count < self.steps:
+            while current_step < total_number_of_steps:
 
-                steps_to_take = min(self.output_frequency, self.steps - current_step_count)
+                steps_to_take = min(self.output_frequency, total_number_of_steps - current_step)
                 integrator.step(steps_to_take)
+
+                current_step += steps_to_take
 
                 state = context.getState(getPositions=True,
                                          getEnergy=True,
@@ -539,75 +611,32 @@ class RunOpenMMSimulation(BaseProtocol):
                                          getParameters=False,
                                          enforcePeriodicBox=self.enable_pbc)
 
-                # Write out the current frame of the trajectory.
-                trajectory_dcd_object.writeModel(positions=state.getPositions(),
-                                                 periodicBoxVectors=state.getPeriodicBoxVectors())
+                simulation.currentStep = current_step
 
-                # Write out the energies and system statistics.
-                raw_statistics[ObservableType.PotentialEnergy][current_step] = \
-                    state.getPotentialEnergy().value_in_unit(simtk_unit.kilojoules_per_mole)
-                raw_statistics[ObservableType.KineticEnergy][current_step] = \
-                    state.getKineticEnergy().value_in_unit(simtk_unit.kilojoules_per_mole)
-                raw_statistics[ObservableType.Volume][current_step] = \
-                    state.getPeriodicBoxVolume().value_in_unit(simtk_unit.angstrom ** 3)
+                # Write out the current state using the reporters.
+                dcd_reporter.report(simulation, state)
+                statistics_reporter.report(simulation, state)
 
-                if self.save_rolling_statistics:
+                if checkpoint_counter >= self.checkpoint_frequency:
+                    # Save to the checkpoint file if needed.
+                    self._write_checkpoint_file(current_step, context)
+                    checkpoint_counter = 0
 
-                    self._write_statistics_array(raw_statistics, current_step, temperature,
-                                                 pressure, degrees_of_freedom, total_mass)
-
-                current_step_count += steps_to_take
-                current_step += 1
+                checkpoint_counter += 1
 
         except Exception as e:
 
             formatted_exception = f'{traceback.format_exception(None, e, e.__traceback__)}'
 
-            result = PropertyEstimatorException(directory=directory,
-                                                message=f'The simulation failed unexpectedly: '
-                                                        f'{formatted_exception}')
-
-        # Create a checkpoint file.
-        state = context.getState(getPositions=True,
-                                 getEnergy=True,
-                                 getVelocities=True,
-                                 getForces=True,
-                                 getParameters=True,
-                                 enforcePeriodicBox=self.enable_pbc)
-
-        state_xml = openmm.XmlSerializer.serialize(state)
-
-        with open(self._checkpoint_path, 'w') as file:
-            file.write(state_xml)
-
-        # Make sure to close the open trajectory stream.
-        trajectory_file_object.close()
-
-        # Save the final statistics
-        self._write_statistics_array(raw_statistics, current_step, temperature,
-                                     pressure, degrees_of_freedom, total_mass)
-
-        if isinstance(result, PropertyEstimatorException):
-            return result
-
-        # Move the trajectory and statistics files to their
-        # final location.
-        os.replace(self._temporary_trajectory_path, self.trajectory_file_path)
-
-        if not os.path.isfile(self.statistics_file_path):
-            os.replace(self._temporary_statistics_path, self.statistics_file_path)
-        else:
-
-            existing_statistics = StatisticsArray.from_pandas_csv(self.statistics_file_path)
-            current_statistics = StatisticsArray.from_pandas_csv(self._temporary_statistics_path)
-
-            concatenated_statistics = StatisticsArray.join(existing_statistics,
-                                                           current_statistics)
-
-            concatenated_statistics.to_pandas_csv(self.statistics_file_path)
+            return PropertyEstimatorException(directory=directory,
+                                              message=f'The simulation failed unexpectedly: '
+                                                      f'{formatted_exception}')
 
         # Save out the final positions.
+        self._write_checkpoint_file(current_step, context)
+
         final_state = context.getState(getPositions=True)
+
         positions = final_state.getPositions()
         topology.setPeriodicBoxVectors(final_state.getPeriodicBoxVectors())
 

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -321,6 +321,9 @@ class RunOpenMMSimulation(BaseProtocol):
         # Run the simulation.
         result = self._simulate(directory, self._context, self._integrator)
 
+        if isinstance(result, PropertyEstimatorException):
+            return result
+
         # Set the output results.
         self.trajectory_file_path = self._local_trajectory_path
         self.statistics_file_path = os.path.join(directory, 'statistics.csv')
@@ -328,7 +331,7 @@ class RunOpenMMSimulation(BaseProtocol):
         statistics = StatisticsArray.from_openmm_csv(self._local_statistics_path, pressure)
         statistics.to_pandas_csv(self.statistics_file_path)
 
-        return result
+        return self._get_output_dictionary()
 
     def _setup_simulation_objects(self, temperature, pressure, available_resources):
         """Initializes the objects needed to perform the simulation.
@@ -646,4 +649,4 @@ class RunOpenMMSimulation(BaseProtocol):
             app.PDBFile.writeFile(topology, positions, configuration_file)
 
         logging.info(f'Simulation performed in the {str(self.ensemble)} ensemble: {self._id}')
-        return self._get_output_dictionary()
+        return None

--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -155,15 +155,15 @@ class RunOpenMMSimulation(BaseProtocol):
     steps_per_iteration = protocol_input(
         docstring='The number of steps to propogate the system by at '
                   'each iteration. The total number of steps performed '
-                  'by this protocol will be `number_of_iterations * '
+                  'by this protocol will be `total_number_of_iterations * '
                   'steps_per_iteration`.',
         type_hint=int, merge_behavior=InequalityMergeBehaviour.LargestValue,
         default_value=1000000
     )
-    number_of_iterations = protocol_input(
+    total_number_of_iterations = protocol_input(
         docstring='The number of times to propogate the system forward by the '
                   '`steps_per_iteration` number of steps. The total number of '
-                  'steps performed by this protocol will be `number_of_iterations * '
+                  'steps performed by this protocol will be `total_number_of_iterations * '
                   'steps_per_iteration`.',
         type_hint=int, merge_behavior=InequalityMergeBehaviour.LargestValue,
         default_value=1
@@ -562,7 +562,7 @@ class RunOpenMMSimulation(BaseProtocol):
         """
 
         # Define how many steps should be taken.
-        total_number_of_steps = self.number_of_iterations * self.steps_per_iteration
+        total_number_of_steps = self.total_number_of_iterations * self.steps_per_iteration
 
         # Try to load the current state from any available checkpoint information
         current_step = self._resume_from_checkpoint(context)

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -299,8 +299,8 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
             conditional_group.add_condition(condition)
 
             # Make sure the simulation gets extended after each iteration.
-            production_simulation.number_of_iterations = ProtocolPath('current_iteration',
-                                                                      conditional_group.id)
+            production_simulation.total_number_of_iterations = ProtocolPath('current_iteration',
+                                                                            conditional_group.id)
 
     conditional_group.add_protocols(production_simulation, analysis_protocol)
 

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -261,7 +261,7 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
 
     equilibration_simulation = simulation.RunOpenMMSimulation(f'equilibration_simulation{id_suffix}')
     equilibration_simulation.ensemble = Ensemble.NPT
-    equilibration_simulation.steps = 100000
+    equilibration_simulation.steps_per_iteration = 100000
     equilibration_simulation.output_frequency = 5000
     equilibration_simulation.timestep = 2.0 * unit.femtosecond
     equilibration_simulation.thermodynamic_state = ProtocolPath('thermodynamic_state', 'global')
@@ -271,7 +271,7 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
     # Production
     production_simulation = simulation.RunOpenMMSimulation(f'production_simulation{id_suffix}')
     production_simulation.ensemble = Ensemble.NPT
-    production_simulation.steps = 1000000
+    production_simulation.steps_per_iteration = 1000000
     production_simulation.output_frequency = 3000
     production_simulation.timestep = 2.0 * unit.femtosecond
     production_simulation.thermodynamic_state = ProtocolPath('thermodynamic_state', 'global')
@@ -297,6 +297,10 @@ def generate_base_simulation_protocols(analysis_protocol, workflow_options, id_s
             condition.condition_type = groups.ConditionalGroup.ConditionType.LessThan
 
             conditional_group.add_condition(condition)
+
+            # Make sure the simulation gets extended after each iteration.
+            production_simulation.number_of_iterations = ProtocolPath('current_iteration',
+                                                                      conditional_group.id)
 
     conditional_group.add_protocols(production_simulation, analysis_protocol)
 

--- a/propertyestimator/tests/test_protocols/test_simulation.py
+++ b/propertyestimator/tests/test_protocols/test_simulation.py
@@ -117,7 +117,7 @@ def test_run_openmm_simulation_checkpoints():
 
             # Fake having saved more frames than expected
             npt_equilibration.steps_per_iteration = 8
-
+            checkpoint.steps_per_iteration = 8
             npt_equilibration.output_frequency = 2
             checkpoint.output_frequency = 2
 

--- a/propertyestimator/tests/test_protocols/test_simulation.py
+++ b/propertyestimator/tests/test_protocols/test_simulation.py
@@ -65,7 +65,7 @@ def test_run_openmm_simulation():
         coordinate_path, system_path = _setup_dummy_system(directory)
 
         npt_equilibration = RunOpenMMSimulation('npt_equilibration')
-        npt_equilibration.steps = 2
+        npt_equilibration.steps_per_iteration = 2
         npt_equilibration.output_frequency = 1
         npt_equilibration.thermodynamic_state = thermodynamic_state
         npt_equilibration.input_coordinate_file = coordinate_path

--- a/propertyestimator/tests/test_protocols/test_simulation.py
+++ b/propertyestimator/tests/test_protocols/test_simulation.py
@@ -1,6 +1,8 @@
 """
 Units tests for propertyestimator.protocols.simulation
 """
+import json
+import os
 import tempfile
 from os import path
 
@@ -13,6 +15,8 @@ from propertyestimator.substances import Substance
 from propertyestimator.tests.utils import build_tip3p_smirnoff_force_field
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils.exceptions import PropertyEstimatorException
+from propertyestimator.utils.serialization import TypedJSONDecoder, TypedJSONEncoder
+from propertyestimator.utils.statistics import StatisticsArray
 
 
 def _setup_dummy_system(directory):
@@ -77,3 +81,50 @@ def test_run_openmm_simulation():
         assert path.isfile(npt_equilibration.output_coordinate_file)
         assert path.isfile(npt_equilibration.trajectory_file_path)
         assert path.isfile(npt_equilibration.statistics_file_path)
+
+
+def test_run_openmm_simulation_checkpoints():
+
+    import mdtraj
+
+    thermodynamic_state = ThermodynamicState(298 * unit.kelvin,
+                                             1.0 * unit.atmosphere)
+
+    with tempfile.TemporaryDirectory() as directory:
+
+        coordinate_path, system_path = _setup_dummy_system(directory)
+
+        # Check that executing twice doesn't run the simulation twice
+        npt_equilibration = RunOpenMMSimulation('npt_equilibration')
+        npt_equilibration.total_number_of_iterations = 1
+        npt_equilibration.steps_per_iteration = 4
+        npt_equilibration.output_frequency = 1
+        npt_equilibration.thermodynamic_state = thermodynamic_state
+        npt_equilibration.input_coordinate_file = coordinate_path
+        npt_equilibration.system_path = system_path
+
+        npt_equilibration.execute(directory, ComputeResources())
+        assert os.path.isfile(npt_equilibration._checkpoint_path)
+        npt_equilibration.execute(directory, ComputeResources())
+
+        assert len(StatisticsArray.from_pandas_csv(npt_equilibration.statistics_file_path)) == 4
+        assert len(mdtraj.load(npt_equilibration.trajectory_file_path, top=coordinate_path)) == 4
+
+        # Make sure that the output files are correctly truncating if more frames
+        # than expected are written
+        with open(npt_equilibration._checkpoint_path, 'r') as file:
+            checkpoint = json.load(file, cls=TypedJSONDecoder)
+
+            # Fake having saved more frames than expected
+            npt_equilibration.steps_per_iteration = 8
+
+            npt_equilibration.output_frequency = 2
+            checkpoint.output_frequency = 2
+
+        with open(npt_equilibration._checkpoint_path, 'w') as file:
+            json.dump(checkpoint, file, cls=TypedJSONEncoder)
+
+        npt_equilibration.execute(directory, ComputeResources())
+
+        assert len(StatisticsArray.from_pandas_csv(npt_equilibration.statistics_file_path)) == 4
+        assert len(mdtraj.load(npt_equilibration.trajectory_file_path, top=coordinate_path)) == 4

--- a/propertyestimator/tests/test_workflow/test_protocols.py
+++ b/propertyestimator/tests/test_workflow/test_protocols.py
@@ -178,7 +178,7 @@ def test_base_simulation_protocols():
 
         npt_equilibration.ensemble = Ensemble.NPT
 
-        npt_equilibration.steps = 20  # Debug settings.
+        npt_equilibration.steps_per_iteration = 20  # Debug settings.
         npt_equilibration.output_frequency = 2  # Debug settings.
 
         npt_equilibration.thermodynamic_state = thermodynamic_state

--- a/propertyestimator/tests/utils.py
+++ b/propertyestimator/tests/utils.py
@@ -118,7 +118,7 @@ def create_debug_density_workflow(max_molecules=128,
     npt_equilibration = simulation.RunOpenMMSimulation('')
     npt_equilibration.schema = density_workflow_schema.protocols['npt_equilibration']
 
-    npt_equilibration.steps = equilibration_steps
+    npt_equilibration.steps_per_iteration = equilibration_steps
     npt_equilibration.output_frequency = equilibration_frequency
 
     density_workflow_schema.protocols['npt_equilibration'] = npt_equilibration.schema
@@ -126,7 +126,7 @@ def create_debug_density_workflow(max_molecules=128,
     converge_uncertainty = groups.ConditionalGroup('')
     converge_uncertainty.schema = density_workflow_schema.protocols['converge_uncertainty']
 
-    converge_uncertainty.protocols['npt_production'].steps = production_steps
+    converge_uncertainty.protocols['npt_production'].steps_per_iteration = production_steps
     converge_uncertainty.protocols['npt_production'].output_frequency = production_frequency
 
     density_workflow_schema.protocols['converge_uncertainty'] = converge_uncertainty.schema

--- a/propertyestimator/utils/statistics.py
+++ b/propertyestimator/utils/statistics.py
@@ -3,6 +3,7 @@ A collection of classes for loading and manipulating statistics data files.
 """
 import copy
 import math
+import re
 from enum import Enum
 from io import StringIO
 
@@ -210,8 +211,6 @@ class StatisticsArray:
         StatisticsArray
             The loaded statistics array.
         """
-        data_array = None
-
         with open(file_path, 'r') as file:
 
             file_contents = file.read()
@@ -220,6 +219,7 @@ class StatisticsArray:
                 return cls()
 
             file_contents = file_contents[1:]
+            file_contents = re.sub('#.*\n', '', file_contents)
 
             string_object = StringIO(file_contents)
             data_array = pd.read_csv(string_object)


### PR DESCRIPTION
## Description
This PR aims to make the `RunOpenMMSimulation` protocol more robust and less 'surprising' to use. 

Previously, if a `RunOpenMMSimulation` protocol was created and executed it would run for `RunOpenMMSimulation.steps` number of steps. If `execute` was called again on that same protocol, it would append to the previous files and run another `RunOpenMMSimulation.steps` number of steps. This made checkpointing difficult to do, as the total number of steps that a protocol should run for was not well defined (i.e. it is difficult to know if the protocol is starting in the middle of the number of requested steps, or it has just finished the requested number of steps and it should do another set).

To alleviate this, the `steps` input has been removed and the protocol now exposes two new convenience inputs - `steps_per_iteration` and `total_number_of_iterations`. By default, `total_number_of_iterations=1` and `steps_per_iteration=1000000`. Running this protocol with these default settings would yield an almost identical behaviour as before, except for now if the protocol was executed twice in a row, a simulation would only be ran for 1000000 steps, rather than 2000000 steps as previously. To run for 2000000 steps as before, the user can either

- increase the `steps_per_iteration` to 2000000.

or

- increase the `total_number_of_iterations ` to 2

or

- run the protocol once with `total_number_of_iterations=1`, increase the `total_number_of_iterations` to 2 then run again - the checkpointing system will detect that 1000000 steps have already been carried out, and so only an extra 1000000 steps will be run for.

In addition, if a user now runs a `RunOpenMMSimulation` with say default settings, and for some reason the protocol is killed halfway after 500000 steps, if the protocol is executed again it will now correctly checkpoint and run for a further 500000 steps, whereas previously the simulation would have been started from scratch.

## Todos

  - [x] Run a few integration tests to ensure correct behaviour.

## Status
- [x] Ready to go