### PR TITLE
Possible Fix for Travis BlockingIOError Errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
 install:
 - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/test_env.yaml
 - conda activate test
+- python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 - python setup.py develop --no-deps
 script:
 - pytest -v --cov=propertyestimator propertyestimator/tests/


### PR DESCRIPTION
## Description
This PR aims to fix an issues which sporadically occurs with mac builds on travis, whereby all tests pass but then the travis build fails with a `BlockingIOError` exception. This is likely related to travis-ci/travis-ci/issues/8920.

## Status
- [X] Ready to go