### PR TITLE
Update Dask Dependencies to 2.6.0

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -26,9 +26,9 @@ dependencies:
   - packmol
   - pymbar
   - mdtraj
-  - dask >=2.5.0
-  - distributed >=2.5.1
-  - dask-jobqueue >=0.6.3
+  - dask >=2.6.0
+  - distributed >=2.6.0
+  - dask-jobqueue >=0.7.0
   - tornado
   - coverage >=4.4
   - uncertainties


### PR DESCRIPTION
## Description
This PR updates the dependencies to use the latest version of `dask`, `distributed` and `dask-jobqueue` to take advantage of the `dask-jobqueue` re-write which greatly stabilises the behaviour of the `dask` based backends.

## Status
- [X] Ready to go