### PR TITLE
Remove rc Label From Installation Instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ Installation from Conda
 
 To install the ``propertyestimator`` from the ``omnia`` channel, simply run::
 
-    conda install -c openeye -c omnia/label/rc propertyestimator
+    conda install -c openeye -c omnia propertyestimator
 
 Optional Dependencies
 ---------------------


### PR DESCRIPTION
## Description
This PR updates the installation instructions to reflect the dropping of the rc label.

## Status
- [X] Ready to go