### PR TITLE
Fix the Default Maximum Energy Minimization Iterations

### DIFF
--- a/propertyestimator/protocols/simulation.py
+++ b/propertyestimator/protocols/simulation.py
@@ -50,7 +50,7 @@ class RunEnergyMinimisation(BaseProtocol):
                   'minimization is continued until the results converge without regard to '
                   'how many iterations it takes.',
         type_hint=int,
-        default_value=10
+        default_value=0
     )
 
     enable_pbc = protocol_input(


### PR DESCRIPTION
## Description
This PR now correctly sets the maximum number of iterations to `0`, i.e. that the minimization should run until the requested tolerance is achieved.

## Status
- [X] Ready to go