### PR TITLE
Multi-State Gradient Reweighting Fixes and Speed-Up

### DIFF
--- a/propertyestimator/properties/density.py
+++ b/propertyestimator/properties/density.py
@@ -1,6 +1,8 @@
 """
 A collection of density physical property definitions.
 """
+import copy
+
 from propertyestimator import unit
 from propertyestimator.datasets.plugins import register_thermoml_property
 from propertyestimator.properties import PhysicalProperty, PropertyPhase
@@ -65,19 +67,19 @@ class Density(PhysicalProperty):
                                                                                       options)
 
         # Set up the gradient calculations
+        coordinate_source = ProtocolPath('output_coordinate_file',
+                                         protocols.equilibration_simulation.id)
+        trajectory_source = ProtocolPath('trajectory_file_path',
+                                         protocols.converge_uncertainty.id,
+                                         protocols.production_simulation.id)
+        statistics_source = ProtocolPath('statistics_file_path',
+                                         protocols.converge_uncertainty.id,
+                                         protocols.production_simulation.id)
+
         reweight_density_template = reweighting.ReweightStatistics('')
         reweight_density_template.statistics_type = ObservableType.Density
-        reweight_density_template.statistics_paths = [
-            ProtocolPath('statistics_file_path',
-                         protocols.converge_uncertainty.id,
-                         protocols.production_simulation.id)
-        ]
-
-        coordinate_source = ProtocolPath('output_coordinate_file', protocols.equilibration_simulation.id)
-        trajectory_source = ProtocolPath('trajectory_file_path', protocols.converge_uncertainty.id,
-                                         protocols.production_simulation.id)
-        statistics_source = ProtocolPath('statistics_file_path', protocols.converge_uncertainty.id,
-                                         protocols.production_simulation.id)
+        reweight_density_template.statistics_paths = statistics_source
+        reweight_density_template.reference_reduced_potentials = statistics_source
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_density_template,
@@ -136,22 +138,17 @@ class Density(PhysicalProperty):
         reweight_density = reweighting.ReweightStatistics(f'reweight_density')
         reweight_density.statistics_type = ObservableType.Density
 
-        reweighting_protocols, data_replicator = generate_base_reweighting_protocols(density_calculation,
-                                                                                     reweight_density,
-                                                                                     options,
-                                                                                     data_replicator_id)
+        protocols, data_replicator = generate_base_reweighting_protocols(density_calculation,
+                                                                         reweight_density,
+                                                                         options,
+                                                                         data_replicator_id)
 
         # Set up the gradient calculations
-        coordinate_path = ProtocolPath('output_coordinate_path', reweighting_protocols.concatenate_trajectories.id)
-        trajectory_path = ProtocolPath('output_trajectory_path', reweighting_protocols.concatenate_trajectories.id)
-        statistics_path = ProtocolPath('statistics_file_path', reweighting_protocols.reduced_target_potential.id)
+        coordinate_path = ProtocolPath('output_coordinate_path', protocols.concatenate_trajectories.id)
+        trajectory_path = ProtocolPath('output_trajectory_path', protocols.concatenate_trajectories.id)
+        statistics_path = ProtocolPath('statistics_file_path', protocols.reduced_target_potential.id)
 
-        reweight_density_template = reweighting.ReweightStatistics('')
-        reweight_density_template.statistics_type = ObservableType.Density
-        reweight_density_template.statistics_paths = ProtocolPath('output_statistics_path',
-                                                                  reweighting_protocols.decorrelate_statistics.id)
-        reweight_density_template.frame_counts = ProtocolPath('number_of_uncorrelated_samples',
-                                                              reweighting_protocols.decorrelate_statistics.id)
+        reweight_density_template = copy.deepcopy(reweight_density)
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_density_template,
@@ -161,19 +158,18 @@ class Density(PhysicalProperty):
                                              statistics_path,
                                              replicator_id='grad',
                                              effective_sample_indices=ProtocolPath('effective_sample_indices',
-                                                                                   reweighting_protocols.
-                                                                                   mbar_protocol.id))
+                                                                                   protocols.mbar_protocol.id))
 
         schema = WorkflowSchema(property_type=Density.__name__)
         schema.id = '{}{}'.format(Density.__name__, 'Schema')
 
-        schema.protocols = {protocol.id: protocol.schema for protocol in reweighting_protocols}
+        schema.protocols = {protocol.id: protocol.schema for protocol in protocols}
         schema.protocols[gradient_group.id] = gradient_group.schema
 
         schema.replicators = [data_replicator, gradient_replicator]
 
         schema.gradients_sources = [gradient_source]
-        schema.final_value_source = ProtocolPath('value', reweighting_protocols.mbar_protocol.id)
+        schema.final_value_source = ProtocolPath('value', protocols.mbar_protocol.id)
 
         return schema
 
@@ -317,21 +313,22 @@ class ExcessMolarVolume(PhysicalProperty):
                                                                                weight_by_mole_fraction.id)
 
         # Set up the gradient calculations
+        coordinate_source = ProtocolPath('output_coordinate_file',
+                                         simulation_protocols.equilibration_simulation.id)
+        trajectory_source = ProtocolPath('trajectory_file_path',
+                                         simulation_protocols.converge_uncertainty.id,
+                                         simulation_protocols.production_simulation.id)
+        statistics_source = ProtocolPath('statistics_file_path',
+                                         simulation_protocols.converge_uncertainty.id,
+                                         simulation_protocols.production_simulation.id)
+
         reweight_molar_volume_template = reweighting.ReweightStatistics('')
         reweight_molar_volume_template.statistics_type = ObservableType.Volume
-        reweight_molar_volume_template.statistics_paths = [ProtocolPath('statistics_file_path',
-                                                                        conditional_group.id,
-                                                                        simulation_protocols.production_simulation.id)]
-
-        coordinate_source = ProtocolPath('output_coordinate_file', simulation_protocols.equilibration_simulation.id)
-        trajectory_source = ProtocolPath('trajectory_file_path', simulation_protocols.converge_uncertainty.id,
-                                         simulation_protocols.production_simulation.id)
-        statistics_source = ProtocolPath('statistics_file_path', simulation_protocols.converge_uncertainty.id,
-                                         simulation_protocols.production_simulation.id)
+        reweight_molar_volume_template.statistics_paths = statistics_source
+        reweight_molar_volume_template.reference_reduced_potentials = statistics_source
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_molar_volume_template,
-                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_source,
                                              trajectory_source,
@@ -465,24 +462,21 @@ class ExcessMolarVolume(PhysicalProperty):
         value_source = ProtocolPath('result', divide_by_molecules.id)
 
         # Set up the gradient calculations.
-        reweight_volume_template = reweighting.ReweightStatistics('')
-        reweight_volume_template.statistics_type = ObservableType.Volume
-        reweight_volume_template.statistics_paths = ProtocolPath('output_statistics_path',
-                                                                 protocols.decorrelate_statistics.id)
+        reweight_volume_template = copy.deepcopy(reweight_volume)
 
         coordinate_path = ProtocolPath('output_coordinate_path', protocols.concatenate_trajectories.id)
         trajectory_path = ProtocolPath('output_trajectory_path', protocols.concatenate_trajectories.id)
+        statistics_path = ProtocolPath('statistics_file_path', protocols.reduced_target_potential.id)
 
         gradient_group, _, gradient_source = \
             generate_gradient_protocol_group(reweight_volume_template,
-                                             ProtocolPath('force_field_path', protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_path,
                                              trajectory_path,
+                                             statistics_path,
                                              replicator_id=gradient_replicator_id,
                                              id_suffix=id_suffix,
                                              substance_source=substance_reference,
-                                             use_subset_of_force_field=False,
                                              effective_sample_indices=ProtocolPath('effective_sample_indices',
                                                                                    protocols.mbar_protocol.id))
 
@@ -554,20 +548,23 @@ class ExcessMolarVolume(PhysicalProperty):
         # different to the mole fractions of the measure property due to rounding.
         full_substance = ProtocolPath('output_substance', full_system_protocols.build_coordinates.id)
 
-        (component_protocols,
-         component_molar_molecules,
-         component_volumes,
-         component_output,
-         component_gradient_group,
-         component_gradient_replicator,
-         component_gradient) = ExcessMolarVolume._get_simulation_protocols('_component',
-                                                                           gradient_replicator_id,
-                                                                           replicator_id=component_replicator_id,
-                                                                           weight_by_mole_fraction=True,
-                                                                           component_substance_reference=
-                                                                                   component_substance,
-                                                                           full_substance_reference=full_substance,
-                                                                           options=options)
+        (
+            component_protocols,
+            component_molar_molecules,
+            component_volumes,
+            component_output,
+            component_gradient_group,
+            component_gradient_replicator,
+            component_gradient
+        ) = ExcessMolarVolume._get_simulation_protocols(
+            '_component',
+            gradient_replicator_id,
+            replicator_id=component_replicator_id,
+            weight_by_mole_fraction=True,
+            component_substance_reference=component_substance,
+            full_substance_reference=full_substance,
+            options=options
+        )
 
         # Finally, set up the protocols which will be responsible for adding together
         # the component molar volumes, and subtracting these from the mixed system molar volume.
@@ -686,18 +683,21 @@ class ExcessMolarVolume(PhysicalProperty):
         # Set up the protocols which will reweight data for each component.
         component_data_replicator_id = f'component_{component_replicator.placeholder_id}_data_replicator'
 
-        (component_protocols,
-         component_volumes,
-         component_data_replicator,
-         component_gradient_group,
-         component_gradient_source) = ExcessMolarVolume._get_reweighting_protocols('_component',
-                                                                                   gradient_replicator.id,
-                                                                                   component_data_replicator_id,
-                                                                                   replicator_id=component_replicator.id,
-                                                                                   weight_by_mole_fraction=True,
-                                                                                   substance_reference=ReplicatorValue(
-                                                                                       component_replicator.id),
-                                                                                   options=options)
+        (
+            component_protocols,
+            component_volumes,
+            component_data_replicator,
+            component_gradient_group,
+            component_gradient_source
+        ) = ExcessMolarVolume._get_reweighting_protocols(
+            '_component',
+            gradient_replicator.id,
+            component_data_replicator_id,
+            replicator_id=component_replicator.id,
+            weight_by_mole_fraction=True,
+            substance_reference=ReplicatorValue(component_replicator.id),
+            options=options
+        )
 
         # Make sure the replicator is only replicating over component data.
         component_data_replicator.template_values = ProtocolPath(f'component_data[$({component_replicator.id})]',

--- a/propertyestimator/properties/density.py
+++ b/propertyestimator/properties/density.py
@@ -67,9 +67,11 @@ class Density(PhysicalProperty):
         # Set up the gradient calculations
         reweight_density_template = reweighting.ReweightStatistics('')
         reweight_density_template.statistics_type = ObservableType.Density
-        reweight_density_template.statistics_paths = [ProtocolPath('statistics_file_path',
-                                                                   protocols.converge_uncertainty.id,
-                                                                   protocols.production_simulation.id)]
+        reweight_density_template.statistics_paths = [
+            ProtocolPath('statistics_file_path',
+                         protocols.converge_uncertainty.id,
+                         protocols.production_simulation.id)
+        ]
 
         coordinate_source = ProtocolPath('output_coordinate_file', protocols.equilibration_simulation.id)
         trajectory_source = ProtocolPath('trajectory_file_path', protocols.converge_uncertainty.id,
@@ -79,7 +81,6 @@ class Density(PhysicalProperty):
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_density_template,
-                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_source,
                                              trajectory_source,
@@ -143,21 +144,22 @@ class Density(PhysicalProperty):
         # Set up the gradient calculations
         coordinate_path = ProtocolPath('output_coordinate_path', reweighting_protocols.concatenate_trajectories.id)
         trajectory_path = ProtocolPath('output_trajectory_path', reweighting_protocols.concatenate_trajectories.id)
+        statistics_path = ProtocolPath('statistics_file_path', reweighting_protocols.reduced_target_potential.id)
 
         reweight_density_template = reweighting.ReweightStatistics('')
         reweight_density_template.statistics_type = ObservableType.Density
         reweight_density_template.statistics_paths = ProtocolPath('output_statistics_path',
                                                                   reweighting_protocols.decorrelate_statistics.id)
+        reweight_density_template.frame_counts = ProtocolPath('number_of_uncorrelated_samples',
+                                                              reweighting_protocols.decorrelate_statistics.id)
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_density_template,
-                                             ProtocolPath('force_field_path',
-                                                          reweighting_protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_path,
                                              trajectory_path,
+                                             statistics_path,
                                              replicator_id='grad',
-                                             use_subset_of_force_field=False,
                                              effective_sample_indices=ProtocolPath('effective_sample_indices',
                                                                                    reweighting_protocols.
                                                                                    mbar_protocol.id))

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -877,6 +877,7 @@ class EnthalpyOfVaporization(PhysicalProperty):
         extract_gas_energy = analysis.ExtractAverageStatistic('extract_gas_energy_'
                                                               f'{data_replicator.placeholder_id}')
         extract_gas_energy.statistics_type = ObservableType.PotentialEnergy
+
         reweight_gas_energy = reweighting.ReweightStatistics('reweight_gas_energy')
         reweight_gas_energy.statistics_type = ObservableType.PotentialEnergy
 

--- a/propertyestimator/properties/enthalpy.py
+++ b/propertyestimator/properties/enthalpy.py
@@ -1,7 +1,7 @@
 """
 A collection of enthalpy physical property definitions.
 """
-
+import copy
 from collections import namedtuple
 
 from propertyestimator import unit
@@ -165,21 +165,22 @@ class EnthalpyOfMixing(PhysicalProperty):
                                                                                weight_by_mole_fraction.id)
 
         # Set up the gradient calculations
+        coordinate_source = ProtocolPath('output_coordinate_file',
+                                         simulation_protocols.equilibration_simulation.id)
+        trajectory_source = ProtocolPath('trajectory_file_path',
+                                         simulation_protocols.converge_uncertainty.id,
+                                         simulation_protocols.production_simulation.id)
+        statistics_source = ProtocolPath('statistics_file_path',
+                                         simulation_protocols.converge_uncertainty.id,
+                                         simulation_protocols.production_simulation.id)
+
         reweight_enthalpy_template = reweighting.ReweightStatistics('')
         reweight_enthalpy_template.statistics_type = ObservableType.PotentialEnergy
-        reweight_enthalpy_template.statistics_paths = [ProtocolPath('statistics_file_path',
-                                                                    conditional_group.id,
-                                                                    simulation_protocols.production_simulation.id)]
-
-        coordinate_source = ProtocolPath('output_coordinate_file', simulation_protocols.equilibration_simulation.id)
-        trajectory_source = ProtocolPath('trajectory_file_path', simulation_protocols.converge_uncertainty.id,
-                                         simulation_protocols.production_simulation.id)
-        statistics_source = ProtocolPath('statistics_file_path', simulation_protocols.converge_uncertainty.id,
-                                         simulation_protocols.production_simulation.id)
+        reweight_enthalpy_template.statistics_paths = statistics_source
+        reweight_enthalpy_template.reference_reduced_potentials = statistics_source
 
         gradient_group, gradient_replicator, gradient_source = \
             generate_gradient_protocol_group(reweight_enthalpy_template,
-                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_source,
                                              trajectory_source,
@@ -314,24 +315,22 @@ class EnthalpyOfMixing(PhysicalProperty):
         value_source = ProtocolPath('result', divide_by_molecules.id)
 
         # Set up the gradient calculations.
-        reweight_potential_template = reweighting.ReweightStatistics('')
+        reweight_potential_template = copy.deepcopy(reweight_enthalpy)
         reweight_potential_template.statistics_type = ObservableType.PotentialEnergy
-        reweight_potential_template.frame_counts = ProtocolPath('number_of_uncorrelated_samples',
-                                                                protocols.decorrelate_statistics.id)
 
         coordinate_path = ProtocolPath('output_coordinate_path', protocols.concatenate_trajectories.id)
         trajectory_path = ProtocolPath('output_trajectory_path', protocols.concatenate_trajectories.id)
+        statistics_path = ProtocolPath('statistics_file_path', protocols.reduced_target_potential.id)
 
         gradient_group, _, gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             ProtocolPath('force_field_path', protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              coordinate_path,
                                              trajectory_path,
+                                             statistics_path,
                                              replicator_id=gradient_replicator_id,
                                              id_suffix=id_suffix,
                                              substance_source=substance_reference,
-                                             use_subset_of_force_field=False,
                                              effective_sample_indices=ProtocolPath('effective_sample_indices',
                                                                                    protocols.mbar_protocol.id))
 
@@ -403,19 +402,22 @@ class EnthalpyOfMixing(PhysicalProperty):
         # different to the mole fractions of the measure property due to rounding.
         full_substance = ProtocolPath('output_substance', full_system_protocols.build_coordinates.id)
 
-        (component_protocols,
-         component_enthalpies,
-         component_output,
-         component_gradient_group,
-         component_gradient_replicator,
-         component_gradient) = EnthalpyOfMixing._get_simulation_protocols('_component',
-                                                                          gradient_replicator_id,
-                                                                          replicator_id=component_replicator_id,
-                                                                          weight_by_mole_fraction=True,
-                                                                          component_substance_reference=
-                                                                                  component_substance,
-                                                                          full_substance_reference=full_substance,
-                                                                          options=options)
+        (
+            component_protocols,
+            component_enthalpies,
+            component_output,
+            component_gradient_group,
+            component_gradient_replicator,
+            component_gradient
+        ) = EnthalpyOfMixing._get_simulation_protocols(
+            '_component',
+            gradient_replicator_id,
+            replicator_id=component_replicator_id,
+            weight_by_mole_fraction=True,
+            component_substance_reference=component_substance,
+            full_substance_reference=full_substance,
+            options=options
+        )
 
         # Finally, set up the protocols which will be responsible for adding together
         # the component enthalpies, and subtracting these from the mixed system enthalpy.
@@ -713,8 +715,9 @@ class EnthalpyOfVaporization(PhysicalProperty):
             condition = groups.ConditionalGroup.Condition()
             condition.condition_type = groups.ConditionalGroup.ConditionType.LessThan
 
-            condition.left_hand_value = ProtocolPath('result.uncertainty', converge_uncertainty.id,
-                                                                           enthalpy_of_vaporization.id)
+            condition.left_hand_value = ProtocolPath('result.uncertainty',
+                                                     converge_uncertainty.id,
+                                                     enthalpy_of_vaporization.id)
             condition.right_hand_value = ProtocolPath('target_uncertainty', 'global')
 
             gas_protocols.production_simulation.total_number_of_iterations = ProtocolPath('current_iteration',
@@ -726,18 +729,21 @@ class EnthalpyOfVaporization(PhysicalProperty):
             converge_uncertainty.add_condition(condition)
 
         # Set up the liquid gradient calculations
+        liquid_coordinate_source = ProtocolPath('output_coordinate_file',
+                                                liquid_protocols.equilibration_simulation.id)
+        liquid_trajectory_source = ProtocolPath('trajectory_file_path',
+                                                liquid_protocols.converge_uncertainty.id,
+                                                liquid_protocols.production_simulation.id)
+        liquid_statistics_source = ProtocolPath('statistics_file_path',
+                                                liquid_protocols.converge_uncertainty.id,
+                                                liquid_protocols.production_simulation.id)
+
         reweight_potential_template = reweighting.ReweightStatistics('')
         reweight_potential_template.statistics_type = ObservableType.PotentialEnergy
-
-        liquid_coordinate_source = ProtocolPath('output_coordinate_file', liquid_protocols.equilibration_simulation.id)
-        liquid_trajectory_source = ProtocolPath('trajectory_file_path', converge_uncertainty.id,
-                                                liquid_protocols.production_simulation.id)
-        liquid_statistics_source = ProtocolPath('statistics_file_path', liquid_protocols.converge_uncertainty.id,
-                                                liquid_protocols.production_simulation.id)
+        reweight_potential_template.reference_reduced_potentials = liquid_statistics_source
 
         liquid_gradient_group, liquid_gradient_replicator, liquid_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              liquid_coordinate_source,
                                              liquid_trajectory_source,
@@ -745,15 +751,19 @@ class EnthalpyOfVaporization(PhysicalProperty):
                                              id_suffix='_liquid')
 
         # Set up the gas gradient calculations
-        gas_coordinate_source = ProtocolPath('output_coordinate_file', gas_protocols.equilibration_simulation.id)
-        gas_trajectory_source = ProtocolPath('trajectory_file_path', converge_uncertainty.id,
-                                                gas_protocols.production_simulation.id)
-        gas_statistics_source = ProtocolPath('statistics_file_path', gas_protocols.converge_uncertainty.id,
+        gas_coordinate_source = ProtocolPath('output_coordinate_file',
+                                             gas_protocols.equilibration_simulation.id)
+        gas_trajectory_source = ProtocolPath('trajectory_file_path',
+                                             gas_protocols.converge_uncertainty.id,
                                              gas_protocols.production_simulation.id)
+        gas_statistics_source = ProtocolPath('statistics_file_path',
+                                             gas_protocols.converge_uncertainty.id,
+                                             gas_protocols.production_simulation.id)
+
+        reweight_potential_template.reference_reduced_potentials = gas_statistics_source
 
         gas_gradient_group, gas_gradient_replicator, gas_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             [ProtocolPath('force_field_path', 'global')],
                                              ProtocolPath('force_field_path', 'global'),
                                              gas_coordinate_source,
                                              gas_trajectory_source,
@@ -915,37 +925,38 @@ class EnthalpyOfVaporization(PhysicalProperty):
         ]
 
         # Set up the liquid phase gradient calculations
-        reweight_potential_template = reweighting.ReweightStatistics('')
-        reweight_potential_template.statistics_type = ObservableType.PotentialEnergy
+        reweight_potential_template = copy.deepcopy(reweight_liquid_energy)
 
         liquid_coordinate_path = ProtocolPath('output_coordinate_path', liquid_protocols.concatenate_trajectories.id)
         liquid_trajectory_path = ProtocolPath('output_trajectory_path', liquid_protocols.concatenate_trajectories.id)
+        liquid_statistics_path = ProtocolPath('statistics_file_path', liquid_protocols.reduced_target_potential.id)
 
         liquid_gradient_group, _, liquid_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             ProtocolPath('force_field_path', liquid_protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              liquid_coordinate_path,
                                              liquid_trajectory_path,
+                                             liquid_statistics_path,
                                              replicator_id=gradient_replicator.id,
                                              id_suffix='_liquid',
-                                             use_subset_of_force_field=False,
                                              effective_sample_indices=ProtocolPath('effective_sample_indices',
                                                                                    liquid_protocols.mbar_protocol.id))
 
         # Set up the gas phase gradient calculations
+        reweight_potential_template = copy.deepcopy(reweight_gas_energy)
+
         gas_coordinate_path = ProtocolPath('output_coordinate_path', gas_protocols.concatenate_trajectories.id)
         gas_trajectory_path = ProtocolPath('output_trajectory_path', gas_protocols.concatenate_trajectories.id)
+        gas_statistics_path = ProtocolPath('statistics_file_path', gas_protocols.reduced_target_potential.id)
 
         gas_gradient_group, _, gas_gradient_source = \
             generate_gradient_protocol_group(reweight_potential_template,
-                                             ProtocolPath('force_field_path', gas_protocols.unpack_stored_data.id),
                                              ProtocolPath('force_field_path', 'global'),
                                              gas_coordinate_path,
                                              gas_trajectory_path,
+                                             gas_statistics_path,
                                              replicator_id=gradient_replicator.id,
                                              id_suffix='_gas',
-                                             use_subset_of_force_field=False,
                                              enable_pbc=False,
                                              effective_sample_indices=ProtocolPath('effective_sample_indices',
                                                                                    gas_protocols.mbar_protocol.id))

--- a/propertyestimator/protocols/gradients.py
+++ b/propertyestimator/protocols/gradients.py
@@ -32,46 +32,30 @@ class GradientReducedPotentials(BaseProtocol):
     of a trajectory using reverse and forward perturbed simulation parameters for
     use with estimating reweighted gradients using the central difference method.
     """
-
-    reference_force_field_paths = protocol_input(
-        docstring='A list of paths to the force field files which were '
-                  'originally used to generate the configurations.',
-        type_hint=list,
-        default_value=UNDEFINED
-    )
     force_field_path = protocol_input(
         docstring='The path to the force field which contains the parameters to '
-                  'differentiate the observable with respect to.',
+                  'differentiate the observable with respect to. When reweighting '
+                  'observables, this should be the `target` force field.',
         type_hint=str,
         default_value=UNDEFINED
     )
-
-    reference_statistics_path = protocol_input(
-        docstring='An optional path to the statistics array which was '
-                  'generated alongside the observable of interest, which will '
-                  'be used to correct the potential energies at the reverse '
-                  'and forward states. This is only really needed when the '
-                  'observable of interest is an energy.',
+    statistics_path = protocol_input(
+        docstring='The path to a statistics array containing potentials '
+                  'evaluated at each frame of the trajectory using the input '
+                  '`force_field_path` and at the input `thermodynamic_state`.',
         type_hint=str,
-        default_value=UNDEFINED,
-        optional=True
+        default_value=UNDEFINED
     )
-
-    enable_pbc = protocol_input(
-        docstring='If true, periodic boundary conditions will be enabled when '
-                  're-evaluating the reduced potentials.',
-        type_hint=bool,
-        default_value=True
+    thermodynamic_state = protocol_input(
+        docstring='The thermodynamic state to estimate the gradients at. When '
+                  'reweighting observables, this should be the `target` state.',
+        type_hint=ThermodynamicState,
+        default_value=UNDEFINED
     )
 
     substance = protocol_input(
         docstring='The substance which describes the composition of the system.',
         type_hint=Substance,
-        default_value=UNDEFINED
-    )
-    thermodynamic_state = protocol_input(
-        docstring='The thermodynamic state to estimate the gradients at.',
-        type_hint=ThermodynamicState,
         default_value=UNDEFINED
     )
 
@@ -87,12 +71,18 @@ class GradientReducedPotentials(BaseProtocol):
         default_value=UNDEFINED
     )
 
+    enable_pbc = protocol_input(
+        docstring='If true, periodic boundary conditions will be enabled when '
+                  're-evaluating the reduced potentials.',
+        type_hint=bool,
+        default_value=True
+    )
+
     parameter_key = protocol_input(
         docstring='The key of the parameter to differentiate with respect to.',
         type_hint=ParameterGradientKey,
         default_value=UNDEFINED
     )
-
     perturbation_scale = protocol_input(
         docstring='The amount to perturb the parameter by, such that '
                   'p_new = p_old * (1 +/- `perturbation_scale`)',
@@ -101,8 +91,8 @@ class GradientReducedPotentials(BaseProtocol):
     )
 
     use_subset_of_force_field = protocol_input(
-        docstring='If true, the reduced potential will be estimated using '
-                  'an OpenMM system which only contains the parameter of '
+        docstring='If true, the reduced potentials will be estimated using '
+                  'an OpenMM system which only contains the parameters of '
                   'interest',
         type_hint=bool,
         default_value=True
@@ -115,11 +105,6 @@ class GradientReducedPotentials(BaseProtocol):
         optional=True
     )
 
-    reference_potential_paths = protocol_output(
-        docstring='File paths to the reduced potentials evaluated using each '
-                  'of the reference force fields.',
-        type_hint=list
-    )
     reverse_potentials_path = protocol_output(
         docstring='A file path to the energies evaluated using the parameters'
                   'perturbed in the reverse direction.',
@@ -130,7 +115,6 @@ class GradientReducedPotentials(BaseProtocol):
                   'perturbed in the forward direction.',
         type_hint=str
     )
-
     reverse_parameter_value = protocol_output(
         docstring='The value of the parameter perturbed in the reverse '
                   'direction.',
@@ -227,7 +211,9 @@ class GradientReducedPotentials(BaseProtocol):
 
     def _evaluate_reduced_potential(self, system, trajectory, file_path,
                                     compute_resources, subset_energy_corrections=None):
-        """Return the potential energy.
+        """Computes the reduced potential of each frame in a trajectory
+        using the provided system.
+
         Parameters
         ----------
         system: simtk.openmm.System
@@ -248,10 +234,8 @@ class GradientReducedPotentials(BaseProtocol):
 
         Returns
         ---------
-        propertyestimator.unit.Quantity
-            A unit bearing `np.ndarray` which contains the reduced potential.
-        PropertyEstimatorException, optional
-            Any exceptions that were raised.
+        StatisticsArray
+            The array containing the reduced potentials.
         """
         from simtk import unit as simtk_unit
 
@@ -299,6 +283,8 @@ class GradientReducedPotentials(BaseProtocol):
         statistics_array[ObservableType.PotentialEnergy] = potentials
         statistics_array.to_pandas_csv(file_path)
 
+        return statistics_array
+
     def execute(self, directory, available_resources):
 
         import mdtraj
@@ -307,26 +293,16 @@ class GradientReducedPotentials(BaseProtocol):
 
         logging.info(f'Calculating the reduced gradient potentials for {self.parameter_key}: {self._id}')
 
-        if len(self.reference_force_field_paths) != 1 and self.use_subset_of_force_field:
-
-            return PropertyEstimatorException(directory, 'A single reference force field must be '
-                                                         'provided when calculating the reduced '
-                                                         'potentials using a subset of the full force')
-
-        if len(self.reference_statistics_path) <= 0 and self.use_subset_of_force_field:
-
-            return PropertyEstimatorException(directory, 'The path to the statistics evaluated using '
-                                                         'the full force field must be provided.')
-
         with open(self.force_field_path) as file:
-            target_force_field_source = ForceFieldSource.parse_json(file.read())
+            force_field_source = ForceFieldSource.parse_json(file.read())
 
-        if not isinstance(target_force_field_source, SmirnoffForceFieldSource):
+        if not isinstance(force_field_source, SmirnoffForceFieldSource):
 
             return PropertyEstimatorException(directory, 'Only SMIRNOFF force fields are supported by '
                                                          'this protocol.')
 
-        target_force_field = target_force_field_source.to_force_field()
+        # Load in the inputs
+        force_field = force_field_source.to_force_field()
 
         trajectory = mdtraj.load_dcd(self.trajectory_file_path,
                                      self.coordinate_file_path)
@@ -341,54 +317,30 @@ class GradientReducedPotentials(BaseProtocol):
         pdb_file = app.PDBFile(self.coordinate_file_path)
         topology = Topology.from_openmm(pdb_file.topology, unique_molecules=unique_molecules)
 
-        # If we are using only a subset of the system object, load in the reference
-        # statistics containing the full system energies to correct the output
-        # forward and reverse potential energies.
-        reference_statistics = None
-        subset_energy_corrections = None
+        # Compute the difference between the energies using the reduced force field,
+        # and the full force field.
+        energy_corrections = None
 
         if self.use_subset_of_force_field:
-            reference_statistics = StatisticsArray.from_pandas_csv(self.reference_statistics_path)
 
-        # Compute the reduced reference energy if any reference force field files
-        # have been provided.
-        self.reference_potential_paths = []
+            target_system, _ = self._build_reduced_system(force_field, topology)
 
-        for index, reference_force_field_path in enumerate(self.reference_force_field_paths):
+            subset_potentials_path = path.join(directory, f'subset.csv')
+            subset_potentials = self._evaluate_reduced_potential(target_system, trajectory,
+                                                                 subset_potentials_path,
+                                                                 available_resources)
 
-            with open(reference_force_field_path) as file:
-                reference_force_field_source = ForceFieldSource.parse_json(file.read())
+            full_statistics = StatisticsArray.from_pandas_csv(self.statistics_path)
 
-            if not isinstance(reference_force_field_source, SmirnoffForceFieldSource):
-                return PropertyEstimatorException(directory, 'Only SMIRNOFF force fields are supported by '
-                                                             'this protocol.')
-
-            reference_force_field = reference_force_field_source.to_force_field()
-            reference_system, _ = self._build_reduced_system(reference_force_field, topology)
-
-            reference_potentials_path = path.join(directory, f'reference_{index}.csv')
-
-            self._evaluate_reduced_potential(reference_system, trajectory,
-                                             reference_potentials_path,
-                                             available_resources)
-
-            self.reference_potential_paths.append(reference_potentials_path)
-
-            if reference_statistics is not None:
-
-                subset_energies = StatisticsArray.from_pandas_csv(reference_potentials_path)
-                subset_energy_corrections = (reference_statistics[ObservableType.PotentialEnergy] -
-                                             subset_energies[ObservableType.PotentialEnergy])
-
-                subset_energies[ObservableType.PotentialEnergy] = reference_statistics[ObservableType.PotentialEnergy]
-                subset_energies.to_pandas_csv(reference_potentials_path)
+            energy_corrections = (full_statistics[ObservableType.PotentialEnergy] -
+                                  subset_potentials[ObservableType.PotentialEnergy])
 
         # Build the slightly perturbed system.
-        reverse_system, reverse_parameter_value = self._build_reduced_system(target_force_field,
+        reverse_system, reverse_parameter_value = self._build_reduced_system(force_field,
                                                                              topology,
                                                                              -self.perturbation_scale)
 
-        forward_system, forward_parameter_value = self._build_reduced_system(target_force_field,
+        forward_system, forward_parameter_value = self._build_reduced_system(force_field,
                                                                              topology,
                                                                              self.perturbation_scale)
 
@@ -400,9 +352,9 @@ class GradientReducedPotentials(BaseProtocol):
         self.forward_potentials_path = path.join(directory, 'forward.csv')
 
         self._evaluate_reduced_potential(reverse_system, trajectory, self.reverse_potentials_path,
-                                         available_resources, subset_energy_corrections)
+                                         available_resources, energy_corrections)
         self._evaluate_reduced_potential(forward_system, trajectory, self.forward_potentials_path,
-                                         available_resources, subset_energy_corrections)
+                                         available_resources, energy_corrections)
 
         logging.info(f'Finished calculating the reduced gradient potentials.')
 

--- a/propertyestimator/protocols/reweighting.py
+++ b/propertyestimator/protocols/reweighting.py
@@ -6,6 +6,7 @@ from os import path
 
 import numpy as np
 import pymbar
+import typing
 from scipy.special import logsumexp
 
 from propertyestimator import unit
@@ -675,7 +676,7 @@ class ReweightStatistics(BaseMBARProtocol):
                   'of interest from each state. If the observable of interest is '
                   'dependant on the changing variable (e.g. the potential energy) then '
                   'this must be a path to the observable re-evaluated at the new state.',
-        type_hint=list,
+        type_hint=typing.Union[list, str],
         default_value=UNDEFINED
     )
     statistics_type = protocol_input(
@@ -694,6 +695,9 @@ class ReweightStatistics(BaseMBARProtocol):
     )
 
     def execute(self, directory, available_resources):
+
+        if isinstance(self.statistics_paths, str):
+            self.statistics_paths = [self.statistics_paths]
 
         if self.statistics_paths is None or len(self.statistics_paths) == 0:
             return PropertyEstimatorException(directory, 'No statistics paths were provided.')

--- a/propertyestimator/protocols/reweighting.py
+++ b/propertyestimator/protocols/reweighting.py
@@ -269,12 +269,12 @@ class BaseMBARProtocol(BaseProtocol):
     reference_reduced_potentials = protocol_input(
         docstring='A list of paths to the reduced potentials of each '
                   'reference state.',
-        type_hint=list,
+        type_hint=typing.Union[str, list],
         default_value=UNDEFINED
     )
     target_reduced_potentials = protocol_input(
         docstring='A list of paths to the reduced potentials of the target state.',
-        type_hint=list,
+        type_hint=typing.Union[str, list],
         default_value=UNDEFINED
     )
 
@@ -323,6 +323,12 @@ class BaseMBARProtocol(BaseProtocol):
         self._reference_observables = []
 
     def execute(self, directory, available_resources):
+
+        if isinstance(self.reference_reduced_potentials, str):
+            self.reference_reduced_potentials = [self.reference_reduced_potentials]
+
+        if isinstance(self.target_reduced_potentials, str):
+            self.target_reduced_potentials = [self.target_reduced_potentials]
 
         if len(self._reference_observables) == 0:
 

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -158,10 +158,6 @@ def generate_base_reweighting_protocols(analysis_protocol, mbar_protocol, workfl
         mbar_protocol.statistics_paths = [ProtocolPath('statistics_file_path', reduced_target_potential.id)]
         mbar_protocol.frame_counts = ProtocolPath('number_of_uncorrelated_samples', decorrelate_statistics.id)
 
-    # TODO: Implement a cleaner way to handle this.
-    if workflow_options.convergence_mode == WorkflowOptions.ConvergenceMode.NoChecks:
-        mbar_protocol.required_effective_samples = -1
-
     base_protocols = BaseReweightingProtocols(unpack_stored_data,
                                               analysis_protocol,
                                               decorrelate_statistics,

--- a/propertyestimator/protocols/utils.py
+++ b/propertyestimator/protocols/utils.py
@@ -143,7 +143,7 @@ def generate_base_reweighting_protocols(analysis_protocol, mbar_protocol, workfl
 
     # Finally, apply MBAR to get the reweighted value.
     mbar_protocol.reference_reduced_potentials = ProtocolPath('statistics_file_path', reduced_reference_potential.id)
-    mbar_protocol.target_reduced_potentials = [ProtocolPath('statistics_file_path', reduced_target_potential.id)]
+    mbar_protocol.target_reduced_potentials = ProtocolPath('statistics_file_path', reduced_target_potential.id)
 
     if (isinstance(mbar_protocol, reweighting.ReweightStatistics) and
         mbar_protocol.statistics_type != ObservableType.PotentialEnergy and
@@ -474,13 +474,13 @@ def generate_gradient_protocol_group(template_reweighting_protocol,
     reverse_mbar_schema.id = f'reverse_reweight{id_suffix}'
     reverse_mbar = available_protocols[reverse_mbar_schema.type](reverse_mbar_schema.id)
     reverse_mbar.schema = reverse_mbar_schema
-    reverse_mbar.target_reduced_potentials = [ProtocolPath('reverse_potentials_path', reduced_potentials.id)]
+    reverse_mbar.target_reduced_potentials = ProtocolPath('reverse_potentials_path', reduced_potentials.id)
 
     forward_mbar_schema = copy.deepcopy(template_reweighting_schema)
     forward_mbar_schema.id = f'forward_reweight{id_suffix}'
     forward_mbar = available_protocols[forward_mbar_schema.type](forward_mbar_schema.id)
     forward_mbar.schema = forward_mbar_schema
-    forward_mbar.target_reduced_potentials = [ProtocolPath('forward_potentials_path', reduced_potentials.id)]
+    forward_mbar.target_reduced_potentials = ProtocolPath('forward_potentials_path', reduced_potentials.id)
 
     if use_target_state_energies:
 

--- a/propertyestimator/tests/test_protocols/test_gradients.py
+++ b/propertyestimator/tests/test_protocols/test_gradients.py
@@ -32,8 +32,7 @@ def test_gradient_reduced_potentials(use_subset):
         reduced_potentials = GradientReducedPotentials(f'reduced_potentials')
         reduced_potentials.substance = substance
         reduced_potentials.thermodynamic_state = thermodynamic_state
-        reduced_potentials.reference_force_field_paths = [force_field_path]
-        reduced_potentials.reference_statistics_path = get_data_filename('test/statistics/stats_pandas.csv')
+        reduced_potentials.statistics_path = get_data_filename('test/statistics/stats_pandas.csv')
         reduced_potentials.force_field_path = force_field_path
         reduced_potentials.trajectory_file_path = get_data_filename('test/trajectories/water.dcd')
         reduced_potentials.coordinate_file_path = get_data_filename('test/trajectories/water.pdb')
@@ -48,9 +47,6 @@ def test_gradient_reduced_potentials(use_subset):
 
         assert path.isfile(reduced_potentials.forward_potentials_path)
         assert path.isfile(reduced_potentials.reverse_potentials_path)
-
-        for reference_path in reduced_potentials.reference_force_field_paths:
-            assert path.isfile(reference_path)
 
 
 def test_central_difference_gradient():

--- a/propertyestimator/tests/test_protocols/test_reweighting.py
+++ b/propertyestimator/tests/test_protocols/test_reweighting.py
@@ -118,9 +118,9 @@ def test_reweight_statistics():
 
         reweight_protocol = ReweightStatistics(f'reduced_potentials')
         reweight_protocol.statistics_type = ObservableType.PotentialEnergy
-        reweight_protocol.statistics_paths = [statistics_path]
-        reweight_protocol.reference_reduced_potentials = [statistics_path]
-        reweight_protocol.target_reduced_potentials = [statistics_path]
+        reweight_protocol.statistics_paths = statistics_path
+        reweight_protocol.reference_reduced_potentials = statistics_path
+        reweight_protocol.target_reduced_potentials = statistics_path
         reweight_protocol.bootstrap_uncertainties = True
         reweight_protocol.required_effective_samples = 0
 


### PR DESCRIPTION
## Description
This PR aims to fix an exception raised when calculating reweighted gradients from data from multiple states. Further, this PR removes a number of redundant reduced potential calculations which should hopefully yield some performance improvements when calculating gradients from multiple states.

## Status
- [x] Ready to go