### PR TITLE
Add Black Compliant isort Settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,13 @@ max-line-length = 88
 ignore = E203, E266, E501, W503
 select = B,C,E,F,W,T4,B9
 
+[isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+
 [versioneer]
 # Automatic version numbering scheme
 VCS = git


### PR DESCRIPTION
## Description
This PR adds settings to the `setup.cfg` file to make `isort` compliant with `black` formatting.

## Status
- [X] Ready to go