### PR TITLE
Fix Dielectric Reweighting

### DIFF
--- a/propertyestimator/protocols/reweighting.py
+++ b/propertyestimator/protocols/reweighting.py
@@ -374,12 +374,6 @@ class BaseMBARProtocol(BaseProtocol):
 
     def execute(self, directory, available_resources):
 
-        if isinstance(self.reference_reduced_potentials, str):
-            self.reference_reduced_potentials = [self.reference_reduced_potentials]
-
-        if isinstance(self.target_reduced_potentials, str):
-            self.target_reduced_potentials = [self.target_reduced_potentials]
-
         if len(self._reference_observables) == 0:
 
             return PropertyEstimatorException(
@@ -426,7 +420,13 @@ class BaseMBARProtocol(BaseProtocol):
             The target reduced potentials array with dtype=double and
             shape=(1,)
         """
+        
+        if isinstance(self.reference_reduced_potentials, str):
+            self.reference_reduced_potentials = [self.reference_reduced_potentials]
 
+        if isinstance(self.target_reduced_potentials, str):
+            self.target_reduced_potentials = [self.target_reduced_potentials]
+        
         reference_reduced_potentials = []
         target_reduced_potentials = []
 


### PR DESCRIPTION
## Description
Fixes an exception raised when estimating dielectric constants by reweighting cached simulation data due to a required `str` -> `list` conversion being missed due to function overriding.

## Status
- [X] Ready to go