### PR TITLE
Update dependencies for 0.0.9 release.

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -17,17 +17,17 @@ dependencies:
   - openeye-toolkits
 
     # Standard dependencies
-  - openforcefield ==0.4.0
+  - openforcefield >=0.4.0
   - smirnoff99frosst
   - numpy
   - pandas
   - openmm
-  - pint
+  - pint ==0.9.0
   - packmol
-  - pymbar
-  - mdtraj
-  - dask >=2.6.0
-  - distributed >=2.6.0
+  - pymbar >=3.0.5
+  - mdtraj >=1.9.3
+  - dask >=2.7.0
+  - distributed >=2.7.0
   - dask-jobqueue >=0.7.0
   - tornado
   - coverage >=4.4


### PR DESCRIPTION
## Description
This PR updates the environment dependency versions to be consistent with omnia ready for the `0.0.9` release. 

Here we pin `pint` to version `0.9.0` as version `0.10.*` introduces breaking changes which will be fixed in the release after `0.0.9`.

## Status
- [X] Ready to go