### PR TITLE
Cleanup Logging

### DIFF
--- a/examples/property_estimator/start_client.py
+++ b/examples/property_estimator/start_client.py
@@ -5,6 +5,8 @@ from propertyestimator import client
 from propertyestimator.datasets.thermoml import ThermoMLDataSet
 from propertyestimator.utils import get_data_filename, setup_timestamp_logging
 
+logger = logging.getLogger(__name__)
+
 
 def main():
     """Submit calculations to a running server instance"""
@@ -30,11 +32,11 @@ def main():
 
     if error is not None:
 
-        logging.info(f"The server failed to complete the request:")
-        logging.info(f"Message: {error.message}")
+        logger.info(f"The server failed to complete the request:")
+        logger.info(f"Message: {error.message}")
         return
 
-    logging.info(f"The server has completed the request.")
+    logger.info(f"The server has completed the request.")
 
     # Save the response
     results.json("results.json")

--- a/examples/property_estimator/start_server.py
+++ b/examples/property_estimator/start_server.py
@@ -6,6 +6,8 @@ from propertyestimator.backends import ComputeResources, DaskLocalCluster
 from propertyestimator.server import EvaluatorServer
 from propertyestimator.utils import setup_timestamp_logging
 
+logger = logging.getLogger(__name__)
+
 
 def validate_inputs(n_workers, cpus_per_worker, gpus_per_worker):
     """Validate the command line inputs.

--- a/integration_tests/trajectory_subsampling/run.py
+++ b/integration_tests/trajectory_subsampling/run.py
@@ -3,6 +3,7 @@ yields correct results relative to subsampling a trajectory fully loaded
 into memory.
 """
 import logging
+
 import time
 
 import numpy as np
@@ -15,6 +16,8 @@ from propertyestimator.protocols.openmm import OpenMMSimulation
 from propertyestimator.substances import Substance
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils import setup_timestamp_logging
+
+logger = logging.getLogger(__name__)
 
 
 def generate_trajectories():

--- a/propertyestimator/__init__.py
+++ b/propertyestimator/__init__.py
@@ -27,8 +27,10 @@ for entry_point in pkg_resources.iter_entry_points("propertyestimator.plugins"):
         import logging
         import traceback
 
+        logger = logging.getLogger(__name__)
+
         formatted_exception = traceback.format_exception(None, e, e.__traceback__)
-        logging.warning(
+        logger.warning(
             f"Could not load the {entry_point} plugin: {formatted_exception}"
         )
 

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -18,6 +18,8 @@ from propertyestimator import unit
 
 from .backends import CalculationBackend, ComputeResources, QueueWorkerResources
 
+logger = logging.getLogger(__name__)
+
 
 class _Multiprocessor:
     """A temporary utility class which runs a given
@@ -136,7 +138,7 @@ class _Multiprocessor:
             formatted_exception = traceback.format_exception(
                 None, return_value[0], return_value[1]
             )
-            logging.info(f"{formatted_exception} {return_value[0]} {return_value[1]}")
+            logger.info(f"{formatted_exception} {return_value[0]} {return_value[1]}")
 
             raise return_value[0]
 
@@ -438,7 +440,7 @@ class BaseDaskJobQueueBackend(BaseDaskBackend):
                 "0" if worker_id not in gpu_assignments else gpu_assignments[worker_id]
             )
 
-            logging.info(
+            logger.info(
                 f"Launching a job with access to GPUs {available_resources._gpu_device_indices}"
             )
 
@@ -735,7 +737,7 @@ class DaskLocalCluster(BaseDaskBackend):
             worker_id = distributed.get_worker().id
             available_resources._gpu_device_indices = gpu_assignments[worker_id]
 
-            logging.info(
+            logger.info(
                 "Launching a job with access to GPUs {}".format(
                     gpu_assignments[worker_id]
                 )

--- a/propertyestimator/backends/dask.py
+++ b/propertyestimator/backends/dask.py
@@ -76,14 +76,14 @@ class _Multiprocessor:
 
                 logger_path = kwargs.pop("logger_path")
 
-                logger = logging.getLogger()
+                worker_logger = logging.getLogger()
 
-                if not len(logger.handlers):
+                if not len(worker_logger.handlers):
                     logger_handler = logging.FileHandler(logger_path)
                     logger_handler.setFormatter(formatter)
 
-                    logger.setLevel(logging.INFO)
-                    logger.addHandler(logger_handler)
+                    worker_logger.setLevel(logging.INFO)
+                    worker_logger.addHandler(logger_handler)
 
             return_value = func(*args, **kwargs)
             queue.put(return_value)
@@ -430,7 +430,10 @@ class BaseDaskJobQueueBackend(BaseDaskBackend):
         if per_worker_logging:
 
             # Each worker should have its own log file.
-            kwargs["logger_path"] = "{}.log".format(get_worker().id)
+            os.makedirs("worker-logs", exist_ok=True)
+            kwargs["logger_path"] = os.path.join(
+                "worker-logs", f"{get_worker().id}.log"
+            )
 
         if available_resources.number_of_gpus > 0:
 

--- a/propertyestimator/client/client.py
+++ b/propertyestimator/client/client.py
@@ -32,6 +32,8 @@ from propertyestimator.utils.tcp import (
     unpack_int,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class ConnectionOptions(AttributeClass):
     """The options to use when connecting to an `EvaluatorServer`
@@ -728,7 +730,7 @@ class EvaluatorClient:
             ):
                 continue
 
-            logging.info(f"The server has completed request {request_id}.")
+            logger.info(f"The server has completed request {request_id}.")
             should_run = False
 
         return response, error

--- a/propertyestimator/datasets/thermoml/thermoml.py
+++ b/propertyestimator/datasets/thermoml/thermoml.py
@@ -20,6 +20,8 @@ from propertyestimator.substances import Component, MoleFraction, Substance
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils.openmm import openmm_quantity_to_pint
 
+logger = logging.getLogger(__name__)
+
 
 def _unit_from_thermoml_string(full_string):
     """Extract the unit from a ThermoML property name.
@@ -2129,7 +2131,7 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
                 return_value = cls.from_xml(response.read(), source)
 
         except HTTPError:
-            logging.warning(f"No ThermoML file could not be found at {url}")
+            logger.warning(f"No ThermoML file could not be found at {url}")
 
         return return_value
 
@@ -2189,7 +2191,7 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
                 return_value = ThermoMLDataSet.from_xml(file.read(), source)
 
         except FileNotFoundError:
-            logging.warning(f"No ThermoML file could not be found at {path}")
+            logger.warning(f"No ThermoML file could not be found at {path}")
 
         return return_value
 
@@ -2212,11 +2214,11 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
         root_node = ElementTree.fromstring(xml)
 
         if root_node is None:
-            logging.warning("The ThermoML XML document could not be parsed.")
+            logger.warning("The ThermoML XML document could not be parsed.")
             return None
 
         if root_node.tag.find("DataReport") < 0:
-            logging.warning(
+            logger.warning(
                 "The ThermoML XML document does not contain the expected root node."
             )
             return None

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -18,6 +18,8 @@ from propertyestimator.datasets import PhysicalProperty
 from propertyestimator.storage.data import BaseStoredData, StoredSimulationData
 from propertyestimator.utils.exceptions import EvaluatorException
 
+logger = logging.getLogger(__name__)
+
 
 def return_args(*args, **_):
     return args
@@ -181,7 +183,7 @@ class CalculationLayer(abc.ABC):
             # Make sure the data directory / file to store actually exists
             if not path.isdir(data_directory_path) or not path.isfile(data_object_path):
 
-                logging.info(
+                logger.info(
                     f"Invalid data directory ({data_directory_path}) / "
                     f"file ({data_object_path})"
                 )
@@ -250,12 +252,12 @@ class CalculationLayer(abc.ABC):
                     # If exceptions were raised, make sure to add them to the list.
                     batch.exceptions.extend(returned_output.exceptions)
 
-                    logging.info(
+                    logger.info(
                         f"Exceptions were raised while executing batch {batch.id}"
                     )
 
                     for exception in returned_output.exceptions:
-                        logging.info(str(exception))
+                        logger.info(str(exception))
 
                 else:
 
@@ -286,7 +288,7 @@ class CalculationLayer(abc.ABC):
 
                     elif len(matches) == 0:
 
-                        logging.info(
+                        logger.info(
                             "A calculation layer returned results for a property not in "
                             "the queue. This sometimes and expectedly occurs when using "
                             "queue based calculation backends, but should be investigated."
@@ -298,7 +300,7 @@ class CalculationLayer(abc.ABC):
 
                     if len(returned_output.exceptions) == 0:
 
-                        logging.info(
+                        logger.info(
                             "A calculation layer did not return an estimated property nor did it "
                             "raise an Exception. This sometimes and expectedly occurs when using "
                             "queue based calculation backends, but should be investigated."
@@ -335,7 +337,7 @@ class CalculationLayer(abc.ABC):
 
         except Exception as e:
 
-            logging.exception(f"Error processing layer results for request {batch.id}")
+            logger.exception(f"Error processing layer results for request {batch.id}")
             exception = EvaluatorException.from_exception(e)
 
             batch.exceptions.append(exception)

--- a/propertyestimator/protocols/coordinates.py
+++ b/propertyestimator/protocols/coordinates.py
@@ -18,6 +18,8 @@ from propertyestimator.workflow.attributes import InputAttribute, OutputAttribut
 from propertyestimator.workflow.plugins import workflow_protocol
 from propertyestimator.workflow.protocols import Protocol
 
+logger = logging.getLogger(__name__)
+
 
 @workflow_protocol()
 class BuildCoordinatesPackmol(Protocol):
@@ -223,7 +225,7 @@ class BuildCoordinatesPackmol(Protocol):
             # noinspection PyTypeChecker
             app.PDBFile.writeFile(topology, simtk_positions, minimised_file)
 
-        logging.info("Coordinates generated: " + self.substance.identifier)
+        logger.info("Coordinates generated: " + self.substance.identifier)
 
     def _execute(self, directory, available_resources):
 
@@ -412,13 +414,13 @@ class BuildDockedCoordinates(Protocol):
                 "The ligand substance must contain a single ligand component."
             )
 
-        logging.info("Initializing the receptor molecule.")
+        logger.info("Initializing the receptor molecule.")
         receptor_molecule = self._create_receptor()
 
-        logging.info("Initializing the ligand molecule.")
+        logger.info("Initializing the ligand molecule.")
         ligand_molecule = self._create_ligand()
 
-        logging.info("Initializing the docking object.")
+        logger.info("Initializing the docking object.")
 
         # Dock the ligand to the receptor.
         dock = oedocking.OEDock()
@@ -426,7 +428,7 @@ class BuildDockedCoordinates(Protocol):
 
         docked_ligand = oechem.OEGraphMol()
 
-        logging.info("Performing the docking.")
+        logger.info("Performing the docking.")
 
         status = dock.DockMultiConformerMolecule(docked_ligand, ligand_molecule)
 

--- a/propertyestimator/protocols/forcefield.py
+++ b/propertyestimator/protocols/forcefield.py
@@ -34,6 +34,8 @@ from propertyestimator.workflow.attributes import InputAttribute, OutputAttribut
 from propertyestimator.workflow.plugins import workflow_protocol
 from propertyestimator.workflow.protocols import Protocol
 
+logger = logging.getLogger(__name__)
+
 
 @workflow_protocol()
 class BaseBuildSystem(Protocol, abc.ABC):
@@ -474,7 +476,7 @@ class BuildLigParGenSystem(BaseBuildSystem):
                 != LigParGenForceFieldSource.ChargeModel.CM1A_1_14
             ):
 
-                logging.warning(
+                logger.warning(
                     f"The preferred charge model is {str(force_field_source.preferred_charge_model)}, "
                     f"however the system is charged and so the "
                     f"{str(LigParGenForceFieldSource.ChargeModel.CM1A_1_14)} model will be used in its "

--- a/propertyestimator/protocols/groups.py
+++ b/propertyestimator/protocols/groups.py
@@ -25,6 +25,8 @@ from propertyestimator.workflow.attributes import (
 from propertyestimator.workflow.plugins import workflow_protocol
 from propertyestimator.workflow.protocols import ProtocolGroup, ProtocolPath
 
+logger = logging.getLogger(__name__)
+
 
 @workflow_protocol()
 class ConditionalGroup(ProtocolGroup):
@@ -138,7 +140,7 @@ class ConditionalGroup(ProtocolGroup):
         ):
             right_hand_value = right_hand_value.to(left_hand_value.units)
 
-        logging.info(
+        logger.info(
             f"Evaluating condition for protocol {self.id}: "
             f"{left_hand_value} {condition.type} {right_hand_value}"
         )
@@ -247,7 +249,7 @@ class ConditionalGroup(ProtocolGroup):
 
             if conditions_met:
 
-                logging.info(
+                logger.info(
                     f"{self.id} loop finished after {self.current_iteration} iterations"
                 )
                 return
@@ -255,7 +257,7 @@ class ConditionalGroup(ProtocolGroup):
             if self.current_iteration >= self.max_iterations:
                 raise RuntimeError(f"{self.id} failed to converge.")
 
-            logging.info(
+            logger.info(
                 f"{self.id} criteria not yet met after {self.current_iteration} "
                 f"iterations"
             )

--- a/propertyestimator/protocols/openmm.py
+++ b/propertyestimator/protocols/openmm.py
@@ -34,6 +34,8 @@ from propertyestimator.utils.serialization import TypedJSONDecoder, TypedJSONEnc
 from propertyestimator.utils.statistics import ObservableType, StatisticsArray
 from propertyestimator.workflow.plugins import workflow_protocol
 
+logger = logging.getLogger(__name__)
+
 
 @workflow_protocol()
 class OpenMMEnergyMinimisation(BaseEnergyMinimisation):
@@ -476,7 +478,7 @@ class OpenMMSimulation(BaseSimulation):
             self._state_path
         ):
 
-            logging.info("No checkpoint files were found.")
+            logger.info("No checkpoint files were found.")
             return current_step_number
 
         if not os.path.isfile(self._local_statistics_path) or not os.path.isfile(
@@ -488,7 +490,7 @@ class OpenMMSimulation(BaseSimulation):
                 "or statistics files seem to be missing. This should not happen."
             )
 
-        logging.info("Restoring the system state from checkpoint files.")
+        logger.info("Restoring the system state from checkpoint files.")
 
         # If they do, load the current state from disk.
         with open(self._state_path, "r") as file:
@@ -536,7 +538,7 @@ class OpenMMSimulation(BaseSimulation):
         # Handle the truncation of the trajectory file.
         self._truncate_trajectory_file(expected_number_of_frames)
 
-        logging.info("System state restored from checkpoint files.")
+        logger.info("System state restored from checkpoint files.")
 
         return checkpoint.current_step_number
 

--- a/propertyestimator/protocols/yank.py
+++ b/propertyestimator/protocols/yank.py
@@ -33,6 +33,8 @@ from propertyestimator.workflow.attributes import (
 from propertyestimator.workflow.plugins import workflow_protocol
 from propertyestimator.workflow.protocols import Protocol
 
+logger = logging.getLogger(__name__)
+
 
 class BaseYankProtocol(Protocol, abc.ABC):
     """An abstract base class for protocols which will performs a set of
@@ -467,7 +469,7 @@ class BaseYankProtocol(Protocol, abc.ABC):
         # If the current thread is not detected as the main one, then yank should
         # be spun up in a new process which should itself be safe to run yank in.
         if threading.current_thread() is threading.main_thread():
-            logging.info("Launching YANK in the main thread.")
+            logger.info("Launching YANK in the main thread.")
             free_energy, free_energy_uncertainty = self._run_yank(
                 directory, available_resources, setup_only
             )
@@ -475,7 +477,7 @@ class BaseYankProtocol(Protocol, abc.ABC):
 
             from multiprocessing import Process, Queue
 
-            logging.info("Launching YANK in a new process.")
+            logger.info("Launching YANK in a new process.")
 
             # Create a queue to pass the results back to the main process.
             queue = Queue()
@@ -965,7 +967,7 @@ class SolvationYankProtocol(BaseYankProtocol):
 
         if vacuum_system_path is not None:
 
-            logging.info(
+            logger.info(
                 f"Disabling the periodic boundary conditions in {vacuum_system_path} "
                 f"by setting the cutoff type to NoCutoff"
             )

--- a/propertyestimator/server/server.py
+++ b/propertyestimator/server/server.py
@@ -27,6 +27,8 @@ from propertyestimator.utils.tcp import (
     unpack_int,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class _Batch(AttributeClass):
     """Represents a batch of physical properties which are
@@ -323,7 +325,7 @@ class EvaluatorServer:
             self._queued_batches.pop(batch.id)
             self._finished_batches[batch.id] = batch
 
-            logging.info(f"Finished server request {batch.id}")
+            logger.info(f"Finished server request {batch.id}")
             return
 
         current_layer_type = batch.options.calculation_layers.pop(0)
@@ -340,7 +342,7 @@ class EvaluatorServer:
             self._launch_batch(batch)
             return
 
-        logging.info(f"Launching batch {batch.id} using the {current_layer_type} layer")
+        logger.info(f"Launching batch {batch.id} using the {current_layer_type} layer")
 
         layer_directory = os.path.join(
             self._working_directory, current_layer_type, batch.id
@@ -372,7 +374,7 @@ class EvaluatorServer:
             The length of the message being received.
         """
 
-        logging.info("Received estimation request from {}".format(address))
+        logger.info("Received estimation request from {}".format(address))
 
         # Read the incoming request from the server. The first four bytes
         # of the response should be the length of the message being sent.
@@ -480,7 +482,7 @@ class EvaluatorServer:
         except ValueError as e:
 
             trace = traceback.format_exception(None, e, e.__traceback__)
-            logging.info(f"Bad message type received: {trace}")
+            logger.info(f"Bad message type received: {trace}")
 
             # Discard the unrecognised message.
             if message_length > 0:
@@ -519,7 +521,7 @@ class EvaluatorServer:
                         to_read.remove(data)
 
         except Exception:
-            logging.exception(f"Fatal error in the main server loop")
+            logger.exception(f"Fatal error in the main server loop")
 
     def start(self, asynchronous=False):
         """Instructs the server to begin listening for incoming
@@ -536,7 +538,7 @@ class EvaluatorServer:
         if self._started:
             raise RuntimeError("The server has already been started.")
 
-        logging.info("Server listening at port {}".format(self._port))
+        logger.info("Server listening at port {}".format(self._port))
         self._started = True
         self._stopped = False
 

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -11,6 +11,8 @@ from simtk import unit as simtk_unit
 from propertyestimator import unit
 from propertyestimator.attributes.attributes import UndefinedAttribute
 
+logger = logging.getLogger(__name__)
+
 
 def setup_platform_with_resources(compute_resources, high_precision=False):
     """Creates an OpenMM `Platform` object which requests a set
@@ -68,7 +70,7 @@ def setup_platform_with_resources(compute_resources, high_precision=False):
         if high_precision:
             platform.setPropertyDefaultValue("Precision", "double")
 
-        logging.info(
+        logger.info(
             "Setting up an openmm platform on GPU {}".format(
                 compute_resources.gpu_device_indices or 0
             )
@@ -86,7 +88,7 @@ def setup_platform_with_resources(compute_resources, high_precision=False):
             # noinspection PyCallByClass,PyTypeChecker
             platform = Platform.getPlatformByName("Reference")
 
-        logging.info(
+        logger.info(
             "Setting up a simulation with {} threads".format(
                 compute_resources.number_of_threads
             )
@@ -199,7 +201,7 @@ def openmm_unit_to_pint(openmm_unit):
         pint_unit = unit(openmm_unit_string).units
     except UndefinedUnitError:
 
-        logging.info(
+        logger.info(
             f"The {openmm_unit_string} OMM unit string (based on the {openmm_unit} object) "
             f"is undefined in pint"
         )
@@ -275,7 +277,7 @@ def pint_unit_to_openmm(pint_unit):
         openmm_unit = string_to_unit(pint_unit_string)
     except AttributeError:
 
-        logging.info(
+        logger.info(
             f"The {pint_unit_string} pint unit string (based on the {pint_unit} object) "
             f"could not be understood by `openforcefield.utils.string_to_unit`"
         )

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -21,6 +21,9 @@ from simtk import openmm
 from propertyestimator import unit
 from propertyestimator.utils.utils import temporarily_change_directory
 
+logger = logging.getLogger(__name__)
+
+
 PACKMOL_PATH = (
     find_executable("packmol") or shutil.which("packmol") or None
     if "PACKMOL" not in os.environ
@@ -240,7 +243,7 @@ def pack_box(
             ).decode("utf-8")
 
             if verbose:
-                logging.info(result)
+                logger.info(result)
 
             packmol_succeeded = result.find("Success!") > 0
 
@@ -254,7 +257,7 @@ def pack_box(
     if not packmol_succeeded:
 
         if verbose:
-            logging.info("Packmol failed to converge")
+            logger.info("Packmol failed to converge")
 
         if os.path.isfile(output_file_path):
             os.unlink(output_file_path)

--- a/propertyestimator/utils/utils.py
+++ b/propertyestimator/utils/utils.py
@@ -9,6 +9,8 @@ import sys
 
 from propertyestimator.utils.string import extract_variable_index_and_name
 
+logger = logging.getLogger(__name__)
+
 
 def find_types_with_decorator(class_type, decorator_type):
     """ A method to collect all attributes marked by a specified
@@ -112,7 +114,7 @@ def create_molecule_from_smiles(smiles, number_of_conformers=1):
 
     if not oechem.OEParseSmiles(molecule, smiles, parse_smiles_options):
 
-        logging.warning("Could not parse SMILES: " + smiles)
+        logger.warning("Could not parse SMILES: " + smiles)
         return None
 
     # Normalize molecule
@@ -135,7 +137,7 @@ def create_molecule_from_smiles(smiles, number_of_conformers=1):
 
         if not status:
 
-            logging.warning("Could not generate a conformer for " + smiles)
+            logger.warning("Could not generate a conformer for " + smiles)
             return None
 
     _cached_molecules[(number_of_conformers, smiles)] = molecule

--- a/propertyestimator/workflow/protocols.py
+++ b/propertyestimator/workflow/protocols.py
@@ -27,6 +27,8 @@ from propertyestimator.workflow.exceptions import WorkflowException
 from propertyestimator.workflow.schemas import ProtocolGroupSchema, ProtocolSchema
 from propertyestimator.workflow.utils import ProtocolPath
 
+logger = logging.getLogger(__name__)
+
 
 class Protocol(AttributeClass, abc.ABC):
     """The base class for a protocol which would form one
@@ -1131,7 +1133,7 @@ class ProtocolGraph:
 
                     protocol.set_value(source_path, target_value)
 
-            logging.info(f"Executing {protocol.id}")
+            logger.info(f"Executing {protocol.id}")
 
             start_time = time.perf_counter()
             protocol.execute(directory, available_resources)
@@ -1142,11 +1144,11 @@ class ProtocolGraph:
             end_time = time.perf_counter()
 
             execution_time = (end_time - start_time) * 1000
-            logging.info(f"{protocol.id} finished executing after {execution_time} ms")
+            logger.info(f"{protocol.id} finished executing after {execution_time} ms")
 
         except Exception as e:
 
-            logging.info(f"Protocol failed to execute: {protocol.id}")
+            logger.info(f"Protocol failed to execute: {protocol.id}")
 
             exception = WorkflowException.from_exception(e)
             exception.protocol_id = protocol.id


### PR DESCRIPTION
## Description
This PR aims to clean up the use of the built-in logging module.

## Todos
  - [x] Change from `logging.*` to `logger = logging.getLogger(__name__)` and `logger.*`
  - [x] Output worker logs in a separate folder.

## Status
- [x] Ready to go