### PR TITLE
Cleanup Serialization of Nested Classes

### DIFF
--- a/integration_tests/properties/binary_data_set.json
+++ b/integration_tests/properties/binary_data_set.json
@@ -33,7 +33,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "O"
@@ -41,7 +41,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "C(CO)CO"
@@ -105,7 +105,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "C(CO)O"
@@ -113,7 +113,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "CO"

--- a/integration_tests/properties/hydration_data_set.json
+++ b/integration_tests/properties/hydration_data_set.json
@@ -32,7 +32,7 @@
             {
               "@type": "propertyestimator.substances.components.Component",
               "role": {
-                "@type": "propertyestimator.substances.components.Component->Role",
+                "@type": "propertyestimator.substances.components.Component.Role",
                 "value": "sol"
               },
               "smiles": "CCC(=O)OC"
@@ -40,7 +40,7 @@
             {
               "@type": "propertyestimator.substances.components.Component",
               "role": {
-                "@type": "propertyestimator.substances.components.Component->Role",
+                "@type": "propertyestimator.substances.components.Component.Role",
                 "value": "solv"
               },
               "smiles": "O"
@@ -103,7 +103,7 @@
             {
               "@type": "propertyestimator.substances.components.Component",
               "role": {
-                "@type": "propertyestimator.substances.components.Component->Role",
+                "@type": "propertyestimator.substances.components.Component.Role",
                 "value": "sol"
               },
               "smiles": "CCCCO"
@@ -111,7 +111,7 @@
             {
               "@type": "propertyestimator.substances.components.Component",
               "role": {
-                "@type": "propertyestimator.substances.components.Component->Role",
+                "@type": "propertyestimator.substances.components.Component.Role",
                 "value": "solv"
               },
               "smiles": "O"
@@ -174,7 +174,7 @@
             {
               "@type": "propertyestimator.substances.components.Component",
               "role": {
-                "@type": "propertyestimator.substances.components.Component->Role",
+                "@type": "propertyestimator.substances.components.Component.Role",
                 "value": "sol"
               },
               "smiles": "c1ccc(cc1)C(=O)N"
@@ -182,7 +182,7 @@
             {
               "@type": "propertyestimator.substances.components.Component",
               "role": {
-                "@type": "propertyestimator.substances.components.Component->Role",
+                "@type": "propertyestimator.substances.components.Component.Role",
                 "value": "solv"
               },
               "smiles": "O"

--- a/integration_tests/properties/pure_data_set.json
+++ b/integration_tests/properties/pure_data_set.json
@@ -27,7 +27,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "CCO"
@@ -83,7 +83,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "CCO"
@@ -139,7 +139,7 @@
             {
               "@type": "propertyestimator.substances.Component",
               "role": {
-                "@type": "propertyestimator.substances.Component->Role",
+                "@type": "propertyestimator.substances.Component.Role",
                 "value": "solv"
               },
               "smiles": "CCO"

--- a/propertyestimator/tests/test_client.py
+++ b/propertyestimator/tests/test_client.py
@@ -22,6 +22,7 @@ from propertyestimator.properties import (
 )
 from propertyestimator.server import EvaluatorServer
 from propertyestimator.tests.utils import create_dummy_property
+from propertyestimator.utils.utils import temporarily_change_directory
 
 property_types = [
     Density,
@@ -85,32 +86,32 @@ def test_submission():
 
     with tempfile.TemporaryDirectory() as directory:
 
-        calculation_backend = DaskLocalCluster()
+        with temporarily_change_directory(directory):
 
-        with calculation_backend:
+            with DaskLocalCluster() as calculation_backend:
 
-            # Spin up a server instance.
-            server = EvaluatorServer(
-                calculation_backend=calculation_backend, working_directory=directory,
-            )
-
-            with server:
-
-                # Connect a client.
-                client = EvaluatorClient()
-
-                # Submit an empty data set.
-                force_field_path = "smirnoff99Frosst-1.1.0.offxml"
-                force_field_source = SmirnoffForceFieldSource.from_path(
-                    force_field_path
+                # Spin up a server instance.
+                server = EvaluatorServer(
+                    calculation_backend=calculation_backend, working_directory=directory,
                 )
 
-                request, error = client.request_estimate(
-                    PhysicalPropertyDataSet(), force_field_source
-                )
-                assert error is None
-                assert isinstance(request, Request)
+                with server:
 
-                result, error = request.results(polling_interval=0.01)
-                assert error is None
-                assert isinstance(result, RequestResult)
+                    # Connect a client.
+                    client = EvaluatorClient()
+
+                    # Submit an empty data set.
+                    force_field_path = "smirnoff99Frosst-1.1.0.offxml"
+                    force_field_source = SmirnoffForceFieldSource.from_path(
+                        force_field_path
+                    )
+
+                    request, error = client.request_estimate(
+                        PhysicalPropertyDataSet(), force_field_source
+                    )
+                    assert error is None
+                    assert isinstance(request, Request)
+
+                    result, error = request.results(polling_interval=0.01)
+                    assert error is None
+                    assert isinstance(result, RequestResult)

--- a/propertyestimator/tests/test_utils/test_serialization.py
+++ b/propertyestimator/tests/test_utils/test_serialization.py
@@ -9,10 +9,13 @@ import pint
 import pytest
 
 from propertyestimator import unit
+from propertyestimator.client import EvaluatorClient
 from propertyestimator.utils.serialization import (
     TypedBaseModel,
     TypedJSONDecoder,
     TypedJSONEncoder,
+    _type_string_to_object,
+    _type_to_type_string,
     deserialize_quantity,
     serialize_quantity,
 )
@@ -293,3 +296,25 @@ def test_pint_serialization():
 
     assert test_value.value == deserialized_value.value
     assert test_value.error == deserialized_value.error
+
+
+def test_type_string_to_object():
+
+    client_class = _type_string_to_object("propertyestimator.client.EvaluatorClient")
+    assert client_class == EvaluatorClient
+
+    nested_class = _type_string_to_object(
+        "propertyestimator.client.EvaluatorClient._Submission"
+    )
+    assert nested_class == EvaluatorClient._Submission
+
+
+def test_type_to_type_string():
+
+    client_string = _type_to_type_string(EvaluatorClient)
+    assert client_string == "propertyestimator.client.client.EvaluatorClient"
+
+    nested_string = _type_to_type_string(EvaluatorClient._Submission)
+    assert (
+        nested_string == "propertyestimator.client.client.EvaluatorClient._Submission"
+    )

--- a/propertyestimator/utils/serialization.py
+++ b/propertyestimator/utils/serialization.py
@@ -31,20 +31,24 @@ def _type_string_to_object(type_string):
             "module_path.class_name: {}".format(type_string)
         )
 
-    module_name = type_string[0:last_period_index]
-    module = importlib.import_module(module_name)
+    type_string_split = type_string.split(".")
+    class_object = None
 
-    class_name = type_string[last_period_index + 1 :]
+    while len(type_string_split) > 0:
 
-    if class_name == "NoneType":
-        return None
+        class_name = type_string_split.pop(0)
 
-    class_name_split = class_name.split("->")
-    class_object = module
+        try:
 
-    while len(class_name_split) > 0:
-        class_name_current = class_name_split.pop(0)
-        class_object = getattr(class_object, class_name_current)
+            # First try and treat the current string as a module
+            module = importlib.import_module(class_name)
+            class_object = module
+
+        except ImportError:
+
+            # If we get an import error, try then to treat the string
+            # as the name of a nested class.
+            class_object = getattr(class_object, class_name)
 
     return class_object
 
@@ -86,7 +90,6 @@ def _type_to_type_string(object_type):
         return "propertyestimator.unit.Quantity"
 
     qualified_name = object_type.__qualname__
-    qualified_name = qualified_name.replace(".", "->")
 
     return_value = "{}.{}".format(object_type.__module__, qualified_name)
     return return_value
@@ -305,7 +308,6 @@ class TypedJSONEncoder(json.JSONEncoder):
             if isinstance(encoder_type, str):
 
                 qualified_name = type_to_serialize.__qualname__
-                qualified_name = qualified_name.replace(".", "->")
 
                 if encoder_type != qualified_name:
                     continue

--- a/propertyestimator/utils/serialization.py
+++ b/propertyestimator/utils/serialization.py
@@ -32,7 +32,9 @@ def _type_string_to_object(type_string):
         )
 
     type_string_split = type_string.split(".")
+
     class_object = None
+    module_path = None
 
     while len(type_string_split) > 0:
 
@@ -40,8 +42,13 @@ def _type_string_to_object(type_string):
 
         try:
 
+            if module_path is None:
+                module_path = class_name
+            else:
+                module_path = module_path + "." + class_name
+
             # First try and treat the current string as a module
-            module = importlib.import_module(class_name)
+            module = importlib.import_module(module_path)
             class_object = module
 
         except ImportError:


### PR DESCRIPTION
## Description
This PR cleans up the JSON serialization of nested classes by replacing the '->' string which previously identified a nested class with a '.' - i.e 

`"@type": "propertyestimator.substances.Component->Role"`

now becomes

`"@type": "propertyestimator.substances.Component.Role"`

## Status
- [x] Ready to go