### PR TITLE
Reduce OpenEye Dependence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,15 @@ before_install:
 install:
 - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/test_env.yaml
 - conda activate test
+
+  # Prevent sporadic travis failures on MacOS.
 - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+
+  # Install the OpenEye toolkits.
+- conda install -c openeye openeye-toolkits
+  # Install this framework.
 - python setup.py develop --no-deps
+
 script:
   - if [[ $LINT == false ]]; then pytest -v --cov=propertyestimator propertyestimator/tests/ ; fi
   - if [[ $LINT == true ]]; then conda install flake8 ; flake8 propertyestimator ; flake8 examples ; fi

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -2,7 +2,6 @@ name: test
 channels:
   - conda-forge
   - omnia
-  - openeye
 dependencies:
     # Base depends
   - python
@@ -13,11 +12,8 @@ dependencies:
   - pytest-cov
   - codecov
 
-    # Commercial
-  - openeye-toolkits
-
     # Standard dependencies
-  - openforcefield >=0.4.0
+  - openforcefield >=0.4.1
   - smirnoff99frosst
   - numpy
   - pandas
@@ -36,3 +32,4 @@ dependencies:
   - pyyaml
   - requests
   - requests-mock # For testing http requests.
+  - cmiles

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,12 +16,19 @@ To install the ``propertyestimator`` from the ``omnia`` channel, simply run::
 
     conda install -c openeye -c omnia propertyestimator
 
-Optional Dependencies
----------------------
+Recommended Dependencies
+------------------------
 
-To parameterize systems with the Amber ``tleap`` tool using a ``TLeapForceFieldSource`` the ``ambertools19`` package must be installed::
+If you have access to the fantastic `OpenEye toolkit <https://docs.eyesopen.com/toolkits/python/index.html>`_ we
+recommend installing this to enable (among many other things) the use of the ``BuildDockedCoordinates`` protocol,
+faster conformer generation, and AM1BCC partial charge calculations::
 
-    conda install -c ambermd 'ambertools ==19.0'
+    conda install -c openeye openeye-toolkits
+
+To parameterize systems with the Amber ``tleap`` tool using a ``TLeapForceFieldSource`` the ``ambertools19`` package
+must be installed::
+
+    conda install -c ambermd 'ambertools >=19.0'
 
 Installation from Source
 ------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -20,8 +20,8 @@ Recommended Dependencies
 ------------------------
 
 If you have access to the fantastic `OpenEye toolkit <https://docs.eyesopen.com/toolkits/python/index.html>`_ we
-recommend installing this to enable (among many other things) the use of the ``BuildDockedCoordinates`` protocol,
-faster conformer generation, and AM1BCC partial charge calculations::
+recommend installing this to enable (among many other things) the use of the ``BuildDockedCoordinates`` protocol and
+faster conformer generation / AM1BCC partial charge calculations::
 
     conda install -c openeye openeye-toolkits
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ Installation from Conda
 
 To install the ``propertyestimator`` from the ``omnia`` channel, simply run::
 
-    conda install -c openeye -c omnia propertyestimator
+    conda install -c omnia propertyestimator
 
 Recommended Dependencies
 ------------------------

--- a/propertyestimator/datasets/datasets.py
+++ b/propertyestimator/datasets/datasets.py
@@ -8,14 +8,12 @@ from enum import IntFlag, unique
 
 import pandas
 import pint
-from simtk.openmm.app import element
 
 from propertyestimator import unit
 from propertyestimator.attributes import UNDEFINED, Attribute, AttributeClass
 from propertyestimator.datasets import CalculationSource, MeasurementSource, Source
 from propertyestimator.substances import MoleFraction, Substance
 from propertyestimator.thermodynamics import ThermodynamicState
-from propertyestimator.utils import create_molecule_from_smiles
 from propertyestimator.utils.serialization import TypedBaseModel
 
 
@@ -420,6 +418,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             The symbols (e.g. C, H, Cl) of the elements to
             retain.
         """
+        from openforcefield.topology import Molecule
 
         def filter_function(physical_property):
 
@@ -427,16 +426,11 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
             for component in substance.components:
 
-                oe_molecule = create_molecule_from_smiles(component.smiles, 0)
+                molecule = Molecule.from_smiles(component.smiles, allow_undefined_stereo=True)
 
-                for atom in oe_molecule.GetAtoms():
+                for atom in molecule.atoms:
 
-                    atomic_number = atom.GetAtomicNum()
-                    atomic_element = element.Element.getByAtomicNumber(
-                        atomic_number
-                    ).symbol
-
-                    if atomic_element in allowed_elements:
+                    if atom.element in allowed_elements:
                         continue
 
                     return False

--- a/propertyestimator/datasets/datasets.py
+++ b/propertyestimator/datasets/datasets.py
@@ -426,13 +426,13 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
             for component in substance.components:
 
-                molecule = Molecule.from_smiles(component.smiles, allow_undefined_stereo=True)
+                molecule = Molecule.from_smiles(
+                    component.smiles, allow_undefined_stereo=True
+                )
 
-                for atom in molecule.atoms:
-
-                    if atom.element in allowed_elements:
-                        continue
-
+                if not all(
+                    [x.element.symbol in allowed_elements for x in molecule.atoms]
+                ):
                     return False
 
             return True

--- a/propertyestimator/datasets/thermoml/thermoml.py
+++ b/propertyestimator/datasets/thermoml/thermoml.py
@@ -394,7 +394,7 @@ class _Compound:
         if not molecule:
             raise ValueError(f"The InchI string ({inchi_string}) could not be parsed")
 
-        return mol_to_smiles(molecule, explicit_hydrogen=False)
+        return mol_to_smiles(molecule, explicit_hydrogen=False, mapped=False)
 
     @staticmethod
     def smiles_from_thermoml_smiles_string(thermoml_string):
@@ -416,7 +416,7 @@ class _Compound:
             raise ValueError("The string cannot be `None`.")
 
         molecule = load_molecule(thermoml_string)
-        return mol_to_smiles(molecule, explicit_hydrogen=False)
+        return mol_to_smiles(molecule, explicit_hydrogen=False, mapped=False)
 
     @staticmethod
     def smiles_from_common_name(common_name):
@@ -442,7 +442,9 @@ class _Compound:
 
             molecule = Molecule.from_iupac(common_name, allow_undefined_stereo=True)
             cmiles_molecule = load_molecule(molecule.to_smiles())
-            smiles = mol_to_smiles(cmiles_molecule, explicit_hydrogen=False)
+            smiles = mol_to_smiles(
+                cmiles_molecule, explicit_hydrogen=False, mapped=False
+            )
 
         except LicenseError:
             smiles = None

--- a/propertyestimator/datasets/thermoml/thermoml.py
+++ b/propertyestimator/datasets/thermoml/thermoml.py
@@ -379,17 +379,22 @@ class _Compound:
         str, optional
             None if the identifier cannot be converted, otherwise the converted SMILES pattern.
         """
-        from openeye import oechem
+        from cmiles.utils import mol_to_smiles
+
+        try:
+            import rdkit.Chem
+        except ImportError:
+            return None
 
         if inchi_string is None:
             raise ValueError("The InChI string cannot be `None`.")
 
-        temp_molecule = oechem.OEMol()
+        molecule = rdkit.Chem.MolFromInchi(inchi_string, removeHs=False)
 
-        if oechem.OEParseInChI(temp_molecule, inchi_string) is False:
-            raise ValueError("All InChI strings in ThermoML files must be valid.")
+        if not molecule:
+            raise ValueError(f"The InchI string ({inchi_string}) could not be parsed")
 
-        return oechem.OEMolToSmiles(temp_molecule)
+        return mol_to_smiles(molecule, explicit_hydrogen=False)
 
     @staticmethod
     def smiles_from_thermoml_smiles_string(thermoml_string):
@@ -405,28 +410,17 @@ class _Compound:
         str, optional
             None if the identifier cannot be converted, otherwise the converted SMILES pattern.
         """
-        from openeye import oechem
+        from cmiles.utils import load_molecule, mol_to_smiles
 
         if thermoml_string is None:
             raise ValueError("The string cannot be `None`.")
 
-        temp_molecule = oechem.OEMol()
-
-        parse_smiles_options = oechem.OEParseSmilesOptions(quiet=True)
-
-        # Should make sure all smiles are OEChem consistent.
-        if (
-            oechem.OEParseSmiles(temp_molecule, thermoml_string, parse_smiles_options)
-            is False
-        ):
-            raise ValueError("All SMILES strings in ThermoML files must be valid.")
-
-        return oechem.OEMolToSmiles(temp_molecule)
+        molecule = load_molecule(thermoml_string)
+        return mol_to_smiles(molecule, explicit_hydrogen=False)
 
     @staticmethod
     def smiles_from_common_name(common_name):
-        """Attempts to create a SMILES pattern from a common molecular name using
-        the `oechem.OEParseIUPACName` method.
+        """Attempts to create a SMILES pattern from an IUPAC name.
 
         Parameters
         ----------
@@ -437,17 +431,21 @@ class _Compound:
         str, None
             None if the identifier cannot be converted, otherwise the converted SMILES pattern.
         """
-        from openeye import oechem
-        from openeye import oeiupac
+        from cmiles.utils import load_molecule, mol_to_smiles
+        from openforcefield.topology import Molecule
+        from openforcefield.utils import LicenseError
 
         if common_name is None:
             return None
 
-        temp_molecule = oechem.OEMol()
-        smiles = None
+        try:
 
-        if oeiupac.OEParseIUPACName(temp_molecule, common_name) is True:
-            smiles = oechem.OEMolToSmiles(temp_molecule)
+            molecule = Molecule.from_iupac(common_name, allow_undefined_stereo=True)
+            cmiles_molecule = load_molecule(molecule.to_smiles())
+            smiles = mol_to_smiles(cmiles_molecule, explicit_hydrogen=False)
+
+        except LicenseError:
+            smiles = None
 
         return smiles
 

--- a/propertyestimator/protocols/coordinates.py
+++ b/propertyestimator/protocols/coordinates.py
@@ -13,7 +13,7 @@ from simtk.openmm import app
 from propertyestimator import unit
 from propertyestimator.attributes import UNDEFINED
 from propertyestimator.substances import Component, ExactAmount, MoleFraction, Substance
-from propertyestimator.utils import create_molecule_from_smiles, packmol
+from propertyestimator.utils import packmol
 from propertyestimator.workflow.attributes import InputAttribute, OutputAttribute
 from propertyestimator.workflow.plugins import workflow_protocol
 from propertyestimator.workflow.protocols import Protocol
@@ -82,27 +82,24 @@ class BuildCoordinatesPackmol(Protocol):
     )
 
     def _build_molecule_arrays(self):
-        """Converts the input substance into a list of openeye OEMol's and a list of
-        counts for how many of each there should be as determined by the `max_molecules`
-        input and the molecules respective mole fractions.
+        """Converts the input substance into a list of molecules and a list
+        of counts for how many of each there should be as determined by the
+        `max_molecules` input and the substances respective mole fractions.
 
         Returns
         -------
-        list of openeye.oechem.OEMol
-            The list of openeye molecules.
+        list of openforcefield.topology.Molecule
+            The list of molecules.
         list of int
             The number of each molecule which should be added to the system.
         """
+        from openforcefield.topology import Molecule
 
         molecules = []
 
         for component in self.substance.components:
 
-            molecule = create_molecule_from_smiles(component.smiles)
-
-            if molecule is None:
-                raise RuntimeError(f"{component} could not be converted to a Molecule")
-
+            molecule = Molecule.from_smiles(component.smiles)
             molecules.append(molecule)
 
         # Determine how many molecules of each type will be present in the system.

--- a/propertyestimator/tests/test_datasets/test_thermoml.py
+++ b/propertyestimator/tests/test_datasets/test_thermoml.py
@@ -10,7 +10,10 @@ from propertyestimator.datasets.thermoml.thermoml import (
     ThermoMLDataSet,
     _unit_from_thermoml_string,
 )
+from propertyestimator.plugins import register_default_plugins
 from propertyestimator.utils import get_data_filename
+
+register_default_plugins()
 
 
 @thermoml_property("Osmotic coefficient", supported_phases=PropertyPhase.Liquid)

--- a/propertyestimator/tests/test_protocols/test_forcefield.py
+++ b/propertyestimator/tests/test_protocols/test_forcefield.py
@@ -34,10 +34,10 @@ def test_build_smirnoff_system():
         with open(force_field_path, "w") as file:
             file.write(build_tip3p_smirnoff_force_field().json())
 
-        substance = Substance.from_components("C", "CO", "C(=O)N")
+        substance = Substance.from_components("C", "O", "CO", "C(=O)N")
 
         build_coordinates = BuildCoordinatesPackmol("build_coordinates")
-        build_coordinates.max_molecules = 9
+        build_coordinates.max_molecules = 8
         build_coordinates.substance = substance
         build_coordinates.execute(directory, None)
 

--- a/propertyestimator/tests/test_utils/test_packmol.py
+++ b/propertyestimator/tests/test_utils/test_packmol.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from propertyestimator import unit
-from propertyestimator.utils import create_molecule_from_smiles, packmol
+from propertyestimator.utils import packmol
 
 
 def _validate_water_results(topology, positions):
@@ -43,10 +43,10 @@ def _validate_paracetamol_results(topology, positions):
 
 
 def test_packmol_packbox():
-    """Test transitive graph reduction utility."""
+    from openforcefield.topology import Molecule
     from simtk import unit as simtk_unit
 
-    molecules = [create_molecule_from_smiles("O")]
+    molecules = [Molecule.from_smiles("O")]
 
     topology, positions = packmol.pack_box(
         molecules, [10], mass_density=1.0 * unit.grams / unit.milliliters
@@ -75,7 +75,7 @@ def test_packmol_packbox():
         packmol.pack_box(molecules, [10, 20], box_size=([20] * 3) * unit.angstrom)
 
     # Test something a bit more tricky than water
-    molecules = [create_molecule_from_smiles("CC(=O)NC1=CC=C(C=C1)O")]
+    molecules = [Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")]
 
     topology, positions = packmol.pack_box(
         molecules, [1], box_size=([20] * 3) * unit.angstrom

--- a/propertyestimator/tests/test_utils/test_utils.py
+++ b/propertyestimator/tests/test_utils/test_utils.py
@@ -1,7 +1,6 @@
 """
 Units tests for propertyestimator.utils.exceptions
 """
-from propertyestimator.utils import utils
 from propertyestimator.utils.utils import get_nested_attribute
 
 
@@ -31,30 +30,6 @@ class DummyDescriptor2:
 
     def __set__(self, instance, value):
         pass
-
-
-class DummyDecoratedClass:
-    @DummyDescriptor1
-    def dummy_function_1(self):
-        pass
-
-    @DummyDescriptor1
-    def dummy_function_2(self):
-        pass
-
-    @DummyDescriptor2
-    def dummy_function_3(self):
-        pass
-
-
-def test_find_decorator():
-    """Test that decorated functions can be identified."""
-
-    types = utils.find_types_with_decorator(DummyDecoratedClass, DummyDescriptor1)
-    assert len(types) == 2 and set(types) == {"dummy_function_1", "dummy_function_2"}
-
-    types = utils.find_types_with_decorator(DummyDecoratedClass, DummyDescriptor2)
-    assert len(types) == 1 and types[0] == "dummy_function_3"
 
 
 def test_get_nested_attribute():

--- a/propertyestimator/utils/__init__.py
+++ b/propertyestimator/utils/__init__.py
@@ -1,13 +1,9 @@
 from .utils import (
-    create_molecule_from_smiles,
-    find_types_with_decorator,
     get_data_filename,
     setup_timestamp_logging,
 )
 
 __all__ = [
-    create_molecule_from_smiles,
-    find_types_with_decorator,
     get_data_filename,
     setup_timestamp_logging,
 ]

--- a/propertyestimator/utils/__init__.py
+++ b/propertyestimator/utils/__init__.py
@@ -1,7 +1,4 @@
-from .utils import (
-    get_data_filename,
-    setup_timestamp_logging,
-)
+from .utils import get_data_filename, setup_timestamp_logging
 
 __all__ = [
     get_data_filename,

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -14,6 +14,7 @@ import string
 import subprocess
 import tempfile
 from distutils.spawn import find_executable
+from functools import reduce
 
 import numpy as np
 from simtk import openmm
@@ -339,7 +340,9 @@ def _approximate_volume_by_density(
 
     for (molecule, number) in zip(molecules, n_copies):
 
-        molecule_mass = sum([atom.mass for atom in molecule.atoms])
+        molecule_mass = reduce(
+            (lambda x, y: x + y), [atom.mass for atom in molecule.atoms]
+        )
         molecule_mass = openmm_quantity_to_pint(molecule_mass) / unit.avogadro_constant
 
         molecule_volume = molecule_mass / mass_density
@@ -485,7 +488,7 @@ def _create_pdb_and_topology(molecule, file_path):
 
         # First try to mol2
         with tempfile.NamedTemporaryFile(suffix=".mol2") as mol2_file:
-            molecule.to_file(mol2_file, file_format="MOL2")
+            molecule.to_file(mol2_file.name, file_format="MOL2")
             mdtraj_molecule = mdtraj.load_mol2(mol2_file.name)
 
     except ValueError:

--- a/propertyestimator/utils/packmol.py
+++ b/propertyestimator/utils/packmol.py
@@ -505,7 +505,20 @@ def _create_pdb_and_topology(molecule, file_path):
         residue_map[residue.name] = None
 
         if smiles == "[H]O[H]":
+
             residue_map[residue.name] = "HOH"
+
+            # Re-assign the water atom names. These need to be set to get
+            # correct CONECT statements.
+            h_counter = 1
+
+            for atom in residue.atoms:
+
+                if atom.element.symbol == "O":
+                    atom.name = "O1"
+                else:
+                    atom.name = f"H{h_counter}"
+                    h_counter += 1
 
         elif smiles == "[Cl-]":
 


### PR DESCRIPTION
## Description
This PR reduces the frameworks dependance on the OpenEye toolkit, mainly by delegating interfacing with it to the OpenFF toolkit or using RdKit where that isn't possible (namely for InchI support until the toolkit supports it - https://github.com/openforcefield/openforcefield/issues/474). While still required by `yank` host-guest binding affinity calculations, this PR essentially removes OpenEye as a required dependency.

## Status
- [X] Ready to go