### PR TITLE
Catch Errors Loading Bad ThermoML Compounds

### DIFF
--- a/propertyestimator/__init__.py
+++ b/propertyestimator/__init__.py
@@ -8,7 +8,7 @@ import warnings
 import pint
 
 from ._version import get_versions
-from .plugins import register_external_plugins
+from .plugins import register_default_plugins, register_external_plugins
 
 unit = pint.UnitRegistry()
 pint.set_application_registry(unit)
@@ -17,6 +17,8 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     pint.Quantity([])
 
+# Load the default plugins
+register_default_plugins()
 # Load in any found external plugins.
 register_external_plugins()
 

--- a/propertyestimator/datasets/thermoml/thermoml.py
+++ b/propertyestimator/datasets/thermoml/thermoml.py
@@ -688,7 +688,7 @@ class _PureOrMixtureData:
 
         Returns
         ----------
-        dict of int and _Constraint, optional
+        list of _Constraint, optional
             The extracted constraints if all could be parsed,
             otherwise `None`.
         """
@@ -725,8 +725,7 @@ class _PureOrMixtureData:
         Returns
         ----------
         dict of int and _VariableDefinition
-            The extracted variable definitions if all could be parsed,
-            otherwise `None`.
+            The extracted variable definitions which could be parsed.
         """
         variable_nodes = node.findall("ThermoML:Variable", namespace)
         variables = {}
@@ -736,7 +735,7 @@ class _PureOrMixtureData:
             variable = _VariableDefinition.from_node(variable_node, namespace)
 
             if not _PureOrMixtureData.validate_constraint(variable, compounds):
-                return None
+                continue
 
             variables[variable.index] = variable
 
@@ -1484,7 +1483,7 @@ class _PureOrMixtureData:
             The xml namespace.
         property_definitions: dict of int and ThermoMLProperty
             The extracted property definitions.
-        global_constraints: dict of int and _Constraint
+        global_constraints: list of _Constraint
             The extracted constraints.
         variable_definitions: dict of int and _VariableDefinition
             The extracted variable definitions.
@@ -1720,13 +1719,6 @@ class _PureOrMixtureData:
                 continue
 
             used_compounds[compound_index] = compounds[compound_index]
-
-        if (
-            property_definitions is None
-            or global_constraints is None
-            or variable_definitions is None
-        ):
-            return []
 
         measured_properties = _PureOrMixtureData.extract_measured_properties(
             node,


### PR DESCRIPTION
## Description
This PR fixes exceptions which were raised when loading ThermoML files which contained compounds which could not be properly parsed (namely those without stereochemistry). The expectation is that these entries (and dependants of such) should be skipped. 

## Status
- [X] Ready to go