### PR TITLE
Remove Layer Code Duplication

### DIFF
--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -367,6 +367,12 @@ class CalculationLayer(abc.ABC):
             layer.
         batch: _Batch
             The batch of properties to estimate with the layer.
+
+        Returns
+        -------
+        list of Future
+            The future objects which will yield the finished `CalculationLayerResult`
+            objects.
         """
         raise NotImplementedError()
 

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -353,7 +353,8 @@ class CalculationLayer(abc.ABC):
         layer_directory,
         batch
     ):
-        """The implementation of the public facing `schedule_calculation` method.
+        """The implementation of the `schedule_calculation` method which is responsible
+        for handling the main layer logic.
 
         Parameters
         ----------

--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -346,6 +346,30 @@ class CalculationLayer(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
+    def _schedule_calculation(
+        cls,
+        calculation_backend,
+        storage_backend,
+        layer_directory,
+        batch
+    ):
+        """The implementation of the public facing `schedule_calculation` method.
+
+        Parameters
+        ----------
+        calculation_backend: CalculationBackend
+            The backend to the submit the calculations to.
+        storage_backend: StorageBackend
+            The backend used to store / retrieve data from previous calculations.
+        layer_directory: str
+            The directory in which to store all temporary calculation data from this
+            layer.
+        batch: _Batch
+            The batch of properties to estimate with the layer.
+        """
+        raise NotImplementedError()
+
+    @classmethod
     def schedule_calculation(
         cls,
         calculation_backend,
@@ -374,4 +398,14 @@ class CalculationLayer(abc.ABC):
             If true, this function will block until the calculation has completed.
             This is mainly intended for debugging purposes.
         """
-        raise NotImplementedError()
+        futures = cls._schedule_calculation(calculation_backend, storage_backend, layer_directory, batch)
+
+        cls._await_results(
+            cls.__name__,
+            calculation_backend,
+            storage_backend,
+            batch,
+            callback,
+            futures,
+            synchronous,
+        )

--- a/propertyestimator/layers/workflow.py
+++ b/propertyestimator/layers/workflow.py
@@ -197,14 +197,12 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
         return results
 
     @classmethod
-    def schedule_calculation(
+    def _schedule_calculation(
         cls,
         calculation_backend,
         storage_backend,
         layer_directory,
         batch,
-        callback,
-        synchronous=False,
     ):
 
         # Store a temporary copy of the force field for protocols to easily access.
@@ -232,15 +230,7 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
             workflow_futures,
         )
 
-        CalculationLayer._await_results(
-            cls.__name__,
-            calculation_backend,
-            storage_backend,
-            batch,
-            callback,
-            [futures],
-            synchronous,
-        )
+        return futures
 
 
 class WorkflowCalculationSchema(CalculationLayerSchema):

--- a/propertyestimator/layers/workflow.py
+++ b/propertyestimator/layers/workflow.py
@@ -223,14 +223,14 @@ class WorkflowCalculationLayer(CalculationLayer, abc.ABC):
 
         workflow_futures = workflow_graph.execute(layer_directory, calculation_backend)
 
-        futures = calculation_backend.submit_task(
+        future = calculation_backend.submit_task(
             WorkflowCalculationLayer.workflow_to_layer_result,
             batch.queued_properties,
             provenance,
             workflow_futures,
         )
 
-        return futures
+        return [future]
 
 
 class WorkflowCalculationSchema(CalculationLayerSchema):

--- a/propertyestimator/tests/test_layers/test_layers.py
+++ b/propertyestimator/tests/test_layers/test_layers.py
@@ -31,14 +31,12 @@ class DummyCalculationLayer(CalculationLayer):
         return CalculationLayerSchema
 
     @classmethod
-    def schedule_calculation(
+    def _schedule_calculation(
         cls,
         calculation_backend,
         storage_backend,
         layer_directory,
-        batch,
-        callback,
-        synchronous=False,
+        batch
     ):
 
         futures = [
@@ -61,15 +59,7 @@ class DummyCalculationLayer(CalculationLayer):
             ),
         ]
 
-        CalculationLayer._await_results(
-            cls.__name__,
-            calculation_backend,
-            storage_backend,
-            batch,
-            callback,
-            futures,
-            synchronous,
-        )
+        return futures
 
     @staticmethod
     def process_successful_property(physical_property, layer_directory, **_):

--- a/propertyestimator/tests/test_server.py
+++ b/propertyestimator/tests/test_server.py
@@ -30,14 +30,12 @@ class QuickCalculationLayer(CalculationLayer):
         return CalculationLayerSchema
 
     @classmethod
-    def schedule_calculation(
+    def _schedule_calculation(
         cls,
         calculation_backend,
         storage_backend,
         layer_directory,
-        batch,
-        callback,
-        synchronous=False,
+        batch
     ):
 
         futures = [
@@ -46,15 +44,7 @@ class QuickCalculationLayer(CalculationLayer):
             ),
         ]
 
-        CalculationLayer._await_results(
-            cls.__name__,
-            calculation_backend,
-            storage_backend,
-            batch,
-            callback,
-            futures,
-            synchronous,
-        )
+        return futures
 
     @staticmethod
     def process_property(physical_property, **_):


### PR DESCRIPTION
## Description
This PR cuts down on the duplicate code that must be added when writing new calculation layers by splitting the `schedule_calculation` function into a public facing function which implements the previously duplicated code, and an internal `_schedule_calculation` which implements the actual layer logic.

## Status
- [X] Ready to go