### PR TITLE
Standardize the Substance API

### DIFF
--- a/propertyestimator/datasets/datasets.py
+++ b/propertyestimator/datasets/datasets.py
@@ -11,7 +11,7 @@ import pint
 from propertyestimator import unit
 from propertyestimator.attributes import UNDEFINED, Attribute, AttributeClass
 from propertyestimator.datasets import CalculationSource, MeasurementSource, Source
-from propertyestimator.substances import MoleFraction, Substance, ExactAmount
+from propertyestimator.substances import ExactAmount, MoleFraction, Substance
 from propertyestimator.thermodynamics import ThermodynamicState
 from propertyestimator.utils.serialization import TypedBaseModel
 
@@ -575,10 +575,7 @@ class PhysicalPropertyDataSet(TypedBaseModel):
                     physical_property.substance.components
                 ):
 
-                    component_amounts = {
-                        MoleFraction: None,
-                        ExactAmount: None
-                    }
+                    component_amounts = {MoleFraction: None, ExactAmount: None}
 
                     for x in physical_property.substance.get_amounts(component):
 
@@ -626,7 +623,9 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
                     data_row[f"Component {index + 1}"] = components[index]
                     data_row[f"Role {index + 1}"] = roles[index]
-                    data_row[f"Mole Fraction {index + 1}"] = amounts[index][MoleFraction]
+                    data_row[f"Mole Fraction {index + 1}"] = amounts[index][
+                        MoleFraction
+                    ]
                     data_row[f"Exact Amount {index + 1}"] = amounts[index][ExactAmount]
 
                 data_row[f"{type(physical_property).__name__} Value"] = value

--- a/propertyestimator/substances/components.py
+++ b/propertyestimator/substances/components.py
@@ -60,7 +60,8 @@ class Component(AttributeClass):
         role: Component.Role
             The role of this component in the system.
         """
-        smiles = self._standardize_smiles(smiles)
+        if smiles != UNDEFINED:
+            smiles = self._standardize_smiles(smiles)
 
         self._set_value("smiles", smiles)
         self._set_value("role", role)

--- a/propertyestimator/substances/substances.py
+++ b/propertyestimator/substances/substances.py
@@ -1,6 +1,8 @@
 """
 An API for defining and creating substances.
 """
+from collections import abc
+
 import numpy as np
 
 from propertyestimator import unit
@@ -11,33 +13,9 @@ from propertyestimator.substances import Amount, Component, ExactAmount, MoleFra
 class Substance(AttributeClass):
     """Defines the components, their amounts, and their roles in a system.
 
-    Examples
+    See Also
     --------
-    A neat liquid containing only a single component:
-
-    >>> from propertyestimator.substances import Component, ExactAmount, MoleFraction
-    >>> liquid = Substance()
-    >>> liquid.add_component(Component(smiles='O'), MoleFraction(1.0))
-
-    A binary mixture containing two components, where the mole fractions are explicitly stated:
-
-    >>> binary_mixture = Substance()
-    >>> binary_mixture.add_component(Component(smiles='O'), MoleFraction(0.2))
-    >>> binary_mixture.add_component(Component(smiles='CO'), MoleFraction(0.8))
-
-    The infinite dilution of one molecule within a bulk solvent or mixture may also be specified
-    by defining the exact number of copies of that molecule, rather than a mole fraction:
-
-    >>> benzene = Component(smiles='C1=CC=CC=C1', role=Component.Role.Solute)
-    >>> water = Component(smiles='O', role=Component.Role.Solvent)
-    >>>
-    >>> infinite_dilution = Substance()
-    >>> infinite_dilution.add_component(component=benzene, amount=ExactAmount(1)) # Infinite dilution.
-    >>> infinite_dilution.add_component(component=water, amount=MoleFraction(1.0))
-
-    In this example we explicitly flag benzene as being the solute and the water component the solvent.
-    This enables workflow's to easily identify key molecules of interest, such as the molecule which should
-    be 'grown' into solution during solvation free energy calculations.
+    physicalproperties
     """
 
     components = Attribute(
@@ -93,10 +71,8 @@ class Substance(AttributeClass):
         return "|".join(identifier_split)
 
     @classmethod
-    def from_components(cls, *components):
+    def from_components(cls, *components, amounts=None):
         """Creates a new `Substance` object from a list of components.
-        This method assumes that all components should be present with
-        equal mole fractions.
 
         Parameters
         ----------
@@ -104,33 +80,78 @@ class Substance(AttributeClass):
             The components to add to the substance. These may either be full
             `Component` objects or just the smiles representation
             of the component.
+        amounts: dict of Component or str and Amount or iterable of Amount, optional
+            The amount of each component being added. Each key should correspond to one
+            of the passed `components`, and the value should be the amount(s) of that
+            component. If `None`, it will be assumed each component is present with
+            an equal mole fraction.
 
         Returns
         -------
         Substance
             The substance containing the requested components in equal amounts.
+
+        See Also
+        --------
+        physicalproperties
         """
 
         if len(components) == 0:
             raise ValueError("At least one component must be specified")
 
-        mole_fraction = 1.0 / len(components)
+        if not all(isinstance(x, (str, Component)) for x in components):
+
+            raise ValueError(
+                "The components must either be string SMILES patterns or "
+                "`Component` objects"
+            )
+
+        # Make sure all of the components have at least one amount defined
+        if amounts is None:
+
+            mole_fraction = 1.0 / len(components)
+            amounts = {x: MoleFraction(mole_fraction) for x in components}
+
+        if not all(x in amounts for x in components):
+            raise ValueError("Each component must have a corresponding amount defined.")
+
+        for amount_key, amount_value in amounts.items():
+
+            if amount_key not in components:
+
+                raise ValueError(
+                    f"The amounts dictionary contained amounts for an undefined "
+                    f"component ({amount_key})."
+                )
+
+            assert isinstance(amount_value, (Amount, abc.Iterable))
+
+            if isinstance(amount_value, Amount):
+                amount_value = [amount_value]
+
+            assert all(isinstance(x, Amount) for x in amount_value)
+            amounts[amount_key] = amount_value
+
+        # Make sure all of the components are Component objects.
+        new_components = [Component(x) if isinstance(x, str) else x for x in components]
+
+        # Create a map of the original components and the new components - these may be
+        # different as each component will standardize its smiles pattern.
+        component_map = {x: y for x, y in zip(components, new_components)}
+
+        new_amounts = {component_map[x]: amounts[x] for x in amounts}
 
         return_substance = cls()
 
-        for component in components:
-
-            if isinstance(component, str):
-                component = Component(smiles=component)
-
-            return_substance.add_component(component, MoleFraction(mole_fraction))
+        for component in new_components:
+            for amount in new_amounts[component]:
+                return_substance._add_component(component, amount)
 
         return return_substance
 
-    def add_component(self, component, amount):
+    def _add_component(self, component, amount):
         """Add a component to the Substance. If the component is already present in
-        the substance, then the mole fraction will be added to the current mole
-        fraction of that component.
+        the substance, then the amount will be added to the current amount of that component.
 
         Parameters
         ----------
@@ -145,29 +166,6 @@ class Substance(AttributeClass):
 
         component.validate()
         amount.validate()
-
-        if isinstance(amount, MoleFraction):
-
-            total_mole_fraction = amount.value
-
-            for component_identifier in self.amounts:
-
-                total_mole_fraction += sum(
-                    [
-                        amount.value
-                        for amount in self.amounts[component_identifier]
-                        if isinstance(amount, MoleFraction)
-                    ]
-                )
-
-            if np.isclose(total_mole_fraction, 1.0):
-                total_mole_fraction = 1.0
-
-            if total_mole_fraction > 1.0:
-
-                raise ValueError(
-                    f"The total mole fraction of this substance {total_mole_fraction} exceeds 1.0"
-                )
 
         if component.identifier not in self.amounts:
 
@@ -331,6 +329,12 @@ class Substance(AttributeClass):
 
         super(Substance, self).__setstate__(state)
 
+    def __len__(self):
+        return len(self.components)
+
+    def __iter__(self):
+        return iter(self.components)
+
     def validate(self, attribute_type=None):
         super(Substance, self).validate(attribute_type)
 
@@ -344,6 +348,7 @@ class Substance(AttributeClass):
         assert all(len(x) > 0 for x in self.amounts.values())
 
         for component in self.components:
+
             component.validate(attribute_type)
             amounts = self.amounts[component.identifier]
 
@@ -351,3 +356,28 @@ class Substance(AttributeClass):
 
             for amount in amounts:
                 amount.validate(attribute_type)
+
+        contains_mole_fraction = any(
+            isinstance(x, MoleFraction) for y in self.amounts.values() for x in y
+        )
+
+        if contains_mole_fraction:
+
+            total_mole_fraction = 0.0
+
+            for component_identifier in self.amounts:
+
+                total_mole_fraction += sum(
+                    [
+                        amount.value
+                        for amount in self.amounts[component_identifier]
+                        if isinstance(amount, MoleFraction)
+                    ]
+                )
+
+            if not np.isclose(total_mole_fraction, 1.0):
+
+                raise ValueError(
+                    f"The total mole fraction of this substance "
+                    f"({total_mole_fraction}) must equal 1.0"
+                )

--- a/propertyestimator/substances/substances.py
+++ b/propertyestimator/substances/substances.py
@@ -1,8 +1,6 @@
 """
 An API for defining and creating substances.
 """
-from collections import abc
-
 import numpy as np
 
 from propertyestimator import unit
@@ -99,12 +97,14 @@ class Substance(AttributeClass):
         """Creates a new `Substance` object from a list of components.
         This method assumes that all components should be present with
         equal mole fractions.
+
         Parameters
         ----------
         components: Component or str
             The components to add to the substance. These may either be full
             `Component` objects or just the smiles representation
             of the component.
+
         Returns
         -------
         Substance
@@ -131,6 +131,7 @@ class Substance(AttributeClass):
         """Add a component to the Substance. If the component is already present in
         the substance, then the mole fraction will be added to the current mole
         fraction of that component.
+
         Parameters
         ----------
         component : Component
@@ -150,6 +151,7 @@ class Substance(AttributeClass):
             total_mole_fraction = amount.value
 
             for component_identifier in self.amounts:
+
                 total_mole_fraction += sum(
                     [
                         amount.value
@@ -162,11 +164,13 @@ class Substance(AttributeClass):
                 total_mole_fraction = 1.0
 
             if total_mole_fraction > 1.0:
+
                 raise ValueError(
                     f"The total mole fraction of this substance {total_mole_fraction} exceeds 1.0"
                 )
 
         if component.identifier not in self.amounts:
+
             components = (*self.components, component)
             self._set_value("components", components)
 
@@ -184,6 +188,7 @@ class Substance(AttributeClass):
         for existing_amount in all_amounts:
 
             if not type(existing_amount) is type(amount):
+
                 remaining_amounts.append(existing_amount)
                 continue
 
@@ -191,6 +196,7 @@ class Substance(AttributeClass):
             break
 
         if existing_amount_of_type is not None:
+
             # Append any existing amounts to the new amount.
             amount = type(amount)(existing_amount_of_type.value + amount.value)
 

--- a/propertyestimator/tests/test_substances.py
+++ b/propertyestimator/tests/test_substances.py
@@ -6,141 +6,49 @@ import numpy as np
 from propertyestimator.substances import Component, ExactAmount, MoleFraction, Substance
 
 
-def test_substance_from_smiles_no_amounts():
+def test_add_mole_fractions():
 
-    substance = Substance.from_smiles("O", "CO")
-    substance.validate()
+    substance = Substance()
 
-    assert substance.number_of_components == 2
+    substance.add_component(Component("C"), MoleFraction(0.5))
+    substance.add_component(Component("C"), MoleFraction(0.5))
 
-    water_amounts = substance.get_amounts(substance.components[0])
-    assert len(water_amounts) == 1
+    assert substance.number_of_components == 1
 
-    assert isinstance(water_amounts[0], MoleFraction)
-    assert np.isclose(water_amounts[0].value, 0.5)
+    amounts = substance.get_amounts(substance.components[0])
 
-    methanol_amounts = substance.get_amounts(substance.components[1])
-    assert len(methanol_amounts) == 1
+    assert len(amounts) == 1
 
-    assert isinstance(methanol_amounts[0], MoleFraction)
-    assert np.isclose(methanol_amounts[0].value, 0.5)
+    amount = next(iter(amounts))
 
-
-def test_substance_from_smiles():
-
-    amounts = {
-        "O": MoleFraction(0.25),
-        "CO": [MoleFraction(0.75), ExactAmount(1)]
-    }
-
-    substance = Substance.from_smiles("O", "CO", amounts=amounts)
-    substance.validate()
-
-    assert substance.number_of_components == 2
-
-    water_amounts = substance.get_amounts(substance.components[0])
-    assert len(water_amounts) == 1
-
-    assert isinstance(water_amounts[0], MoleFraction)
-    assert np.isclose(water_amounts[0].value, 0.25)
-
-    methanol_amounts = substance.get_amounts(substance.components[1])
-    assert len(methanol_amounts) == 2
-
-    assert isinstance(methanol_amounts[0], MoleFraction)
-    assert np.isclose(methanol_amounts[0].value, 0.75)
-
-    assert isinstance(methanol_amounts[1], ExactAmount)
-    assert np.isclose(methanol_amounts[1].value, 1)
+    assert isinstance(amount, MoleFraction)
+    assert np.isclose(amount.value, 1.0)
 
 
-def test_substance_components_no_amounts():
+def test_multiple_amounts():
 
-    substance = Substance.from_smiles("O", "CO")
-    substance.validate()
+    substance = Substance()
+
+    sodium = Component("[Na+]")
+    chloride = Component("[Cl-]")
+
+    substance.add_component(sodium, MoleFraction(0.75))
+    substance.add_component(sodium, ExactAmount(1))
+
+    substance.add_component(chloride, MoleFraction(0.25))
+    substance.add_component(chloride, ExactAmount(1))
 
     assert substance.number_of_components == 2
 
-    water_amounts = substance.get_amounts(substance.components[0])
-    assert len(water_amounts) == 1
+    sodium_amounts = substance.get_amounts(sodium)
+    chlorine_amounts = substance.get_amounts(chloride)
 
-    assert isinstance(water_amounts[0], MoleFraction)
-    assert np.isclose(water_amounts[0].value, 0.5)
+    assert len(sodium_amounts) == 2
+    assert len(chlorine_amounts) == 2
 
-    methanol_amounts = substance.get_amounts(substance.components[1])
-    assert len(methanol_amounts) == 1
+    molecule_counts = substance.get_molecules_per_component(6)
 
-    assert isinstance(methanol_amounts[0], MoleFraction)
-    assert np.isclose(methanol_amounts[0].value, 0.5)
+    assert len(molecule_counts) == 2
 
-
-def test_substance_from_smiles():
-
-    amounts = {
-        "O": MoleFraction(0.25),
-        "CO": [MoleFraction(0.75), ExactAmount(1)]
-    }
-
-    substance = Substance.from_smiles("O", "CO", amounts=amounts)
-    substance.validate()
-
-    assert substance.number_of_components == 2
-
-    water_amounts = substance.get_amounts(substance.components[0])
-    assert len(water_amounts) == 1
-
-    assert isinstance(water_amounts[0], MoleFraction)
-    assert np.isclose(water_amounts[0].value, 0.25)
-
-    methanol_amounts = substance.get_amounts(substance.components[1])
-    assert len(methanol_amounts) == 2
-
-    assert isinstance(methanol_amounts[0], MoleFraction)
-    assert np.isclose(methanol_amounts[0].value, 0.75)
-
-    assert isinstance(methanol_amounts[1], ExactAmount)
-    assert np.isclose(methanol_amounts[1].value, 1)
-
-
-def test_substance_from_components_with_roles():
-
-    sodium_solvent = Component(smiles="[Na+]", role=Component.Role.Solvent)
-    chloride_solvent = Component(smiles="[Cl-]", role=Component.Role.Solvent)
-
-    sodium_solute = Component(smiles="[Na+]", role=Component.Role.Solute)
-    chloride_solute = Component(smiles="[Cl-]", role=Component.Role.Solute)
-
-    amounts = {
-        sodium_solute: MoleFraction(0.75),
-        sodium_solvent: ExactAmount(1),
-        chloride_solvent: MoleFraction(0.25),
-        chloride_solute: ExactAmount(1),
-    }
-
-    substance = Substance.from_components(sodium_solvent, sodium_solute, chloride_solvent, chloride_solute, amounts=amounts)
-
-    assert len(substance) == 4
-
-    for component in substance:
-        assert len(substance.get_amounts(component)) == 1
-
-
-def test_len():
-
-    substance = Substance.from_components("O", "CO")
-    assert len(substance) == 2
-
-
-def test_iter():
-
-    water = Component("O")
-    methanol = Component("CO")
-
-    substance = Substance.from_components(water, methanol)
-
-    components = []
-
-    for component in substance:
-        components.append(component)
-
-    assert components == [water, methanol]
+    assert molecule_counts[sodium.identifier] == 4
+    assert molecule_counts[chloride.identifier] == 2

--- a/propertyestimator/tests/test_substances.py
+++ b/propertyestimator/tests/test_substances.py
@@ -2,8 +2,24 @@
 Units tests for propertyestimator.substances
 """
 import numpy as np
+import pytest
 
 from propertyestimator.substances import Component, ExactAmount, MoleFraction, Substance
+
+
+@pytest.mark.parametrize(
+    "smiles,expected",
+    [
+        ("C1=CC=CC=C1", "c1ccccc1"),
+        ("c1ccccc1", "c1ccccc1"),
+        ("[C@H](F)(Cl)Br", "[C@H](F)(Cl)Br"),
+        ("C(F)(Cl)Br", "C(F)(Cl)Br"),
+    ],
+)
+def test_component_standardization(smiles, expected):
+
+    component = Component(smiles=smiles)
+    assert component.smiles == expected
 
 
 def test_add_mole_fractions():
@@ -52,3 +68,9 @@ def test_multiple_amounts():
 
     assert molecule_counts[sodium.identifier] == 4
     assert molecule_counts[chloride.identifier] == 2
+
+
+def test_substance_len():
+
+    substance = Substance.from_components("C", "CC", "CCC", "CCC")
+    assert len(substance) == 3

--- a/propertyestimator/tests/test_substances.py
+++ b/propertyestimator/tests/test_substances.py
@@ -6,52 +6,100 @@ import numpy as np
 from propertyestimator.substances import Component, ExactAmount, MoleFraction, Substance
 
 
-def test_substance_from_components_no_amounts():
+def test_substance_from_smiles_no_amounts():
 
-    water = Component(smiles="O")
-    methanol = "CO"
-
-    substance = Substance.from_components(water, methanol)
+    substance = Substance.from_smiles("O", "CO")
     substance.validate()
 
     assert substance.number_of_components == 2
 
-    amounts = substance.get_amounts(substance.components[0])
+    water_amounts = substance.get_amounts(substance.components[0])
+    assert len(water_amounts) == 1
 
-    assert len(amounts) == 1
+    assert isinstance(water_amounts[0], MoleFraction)
+    assert np.isclose(water_amounts[0].value, 0.5)
 
-    amount = next(iter(amounts))
+    methanol_amounts = substance.get_amounts(substance.components[1])
+    assert len(methanol_amounts) == 1
 
-    assert isinstance(amount, MoleFraction)
-    assert np.isclose(amount.value, 0.5)
+    assert isinstance(methanol_amounts[0], MoleFraction)
+    assert np.isclose(methanol_amounts[0].value, 0.5)
 
 
-def test_substance_from_components():
-
-    sodium = Component(smiles="[Na+]")
-    chloride = Component(smiles="[Cl-]")
+def test_substance_from_smiles():
 
     amounts = {
-        sodium: [MoleFraction(0.75), ExactAmount(1)],
-        chloride: [MoleFraction(0.25), ExactAmount(1)]
+        "O": MoleFraction(0.25),
+        "CO": [MoleFraction(0.75), ExactAmount(1)]
     }
 
-    substance = Substance.from_components(sodium, chloride, amounts=amounts)
+    substance = Substance.from_smiles("O", "CO", amounts=amounts)
+    substance.validate()
 
-    assert len(substance) == 2
+    assert substance.number_of_components == 2
 
-    sodium_amounts = substance.get_amounts(sodium)
-    chlorine_amounts = substance.get_amounts(chloride)
+    water_amounts = substance.get_amounts(substance.components[0])
+    assert len(water_amounts) == 1
 
-    assert len(sodium_amounts) == 2
-    assert len(chlorine_amounts) == 2
+    assert isinstance(water_amounts[0], MoleFraction)
+    assert np.isclose(water_amounts[0].value, 0.25)
 
-    molecule_counts = substance.get_molecules_per_component(6)
+    methanol_amounts = substance.get_amounts(substance.components[1])
+    assert len(methanol_amounts) == 2
 
-    assert len(molecule_counts) == 2
+    assert isinstance(methanol_amounts[0], MoleFraction)
+    assert np.isclose(methanol_amounts[0].value, 0.75)
 
-    assert molecule_counts[sodium.identifier] == 4
-    assert molecule_counts[chloride.identifier] == 2
+    assert isinstance(methanol_amounts[1], ExactAmount)
+    assert np.isclose(methanol_amounts[1].value, 1)
+
+
+def test_substance_components_no_amounts():
+
+    substance = Substance.from_smiles("O", "CO")
+    substance.validate()
+
+    assert substance.number_of_components == 2
+
+    water_amounts = substance.get_amounts(substance.components[0])
+    assert len(water_amounts) == 1
+
+    assert isinstance(water_amounts[0], MoleFraction)
+    assert np.isclose(water_amounts[0].value, 0.5)
+
+    methanol_amounts = substance.get_amounts(substance.components[1])
+    assert len(methanol_amounts) == 1
+
+    assert isinstance(methanol_amounts[0], MoleFraction)
+    assert np.isclose(methanol_amounts[0].value, 0.5)
+
+
+def test_substance_from_smiles():
+
+    amounts = {
+        "O": MoleFraction(0.25),
+        "CO": [MoleFraction(0.75), ExactAmount(1)]
+    }
+
+    substance = Substance.from_smiles("O", "CO", amounts=amounts)
+    substance.validate()
+
+    assert substance.number_of_components == 2
+
+    water_amounts = substance.get_amounts(substance.components[0])
+    assert len(water_amounts) == 1
+
+    assert isinstance(water_amounts[0], MoleFraction)
+    assert np.isclose(water_amounts[0].value, 0.25)
+
+    methanol_amounts = substance.get_amounts(substance.components[1])
+    assert len(methanol_amounts) == 2
+
+    assert isinstance(methanol_amounts[0], MoleFraction)
+    assert np.isclose(methanol_amounts[0].value, 0.75)
+
+    assert isinstance(methanol_amounts[1], ExactAmount)
+    assert np.isclose(methanol_amounts[1].value, 1)
 
 
 def test_substance_from_components_with_roles():


### PR DESCRIPTION
## Description
This PR aims to standardize the substance API by 

 - Adding missing python features such as a `__len__` and `__iter__` implementation. This should make the object more intuitive / easier to use.

 - Use cmiles to standardize component smiles strings on creation. This should help standardize things across the framework, such as when filtering, comparing for equality of substances etc.

## Status
- [x] Ready to go