### PR TITLE
Fix Workflow Schema Containing Protocols

### DIFF
--- a/propertyestimator/workflow/workflow.py
+++ b/propertyestimator/workflow/workflow.py
@@ -105,7 +105,7 @@ class Workflow:
         schema = WorkflowSchema()
 
         schema.id = self.uuid
-        schema.protocol_schemas = [copy.deepcopy(x) for x in self._protocols]
+        schema.protocol_schemas = [copy.deepcopy(x.schema) for x in self._protocols]
 
         if self._final_value_source != UNDEFINED:
             schema.final_value_source = self._final_value_source.copy()


### PR DESCRIPTION
## Description
This PR fixes a bug whereby a `WorkflowSchema` created from a `Workflow` would populate the `protocol_schemas` attribute would JSON serialized protocols, rather than their schemas.

## Status
- [X] Ready to go