### PR TITLE
Refactor Data Set

### DIFF
--- a/propertyestimator/client/client.py
+++ b/propertyestimator/client/client.py
@@ -507,11 +507,8 @@ class EvaluatorClient:
             request.
         """
 
-        property_types = set()
-
         # Retrieve the types of properties in the data set.
-        for property_list in data_set.properties.values():
-            property_types.update([x.__class__.__name__ for x in property_list])
+        property_types = data_set.property_types
 
         if options.calculation_schemas == UNDEFINED:
             options.calculation_schemas = defaultdict(dict)

--- a/propertyestimator/datasets/datasets.py
+++ b/propertyestimator/datasets/datasets.py
@@ -167,30 +167,31 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         """
         Constructs a new PhysicalPropertyDataSet object.
         """
-        self._properties = {}
-        self._sources = []
+        self._properties = []
 
     @property
     def properties(self):
+        """tuple of PhysicalProperty: A list of all of the properties
+        within this set.
         """
-        dict of str and list of PhysicalProperty: A list of all of the properties
-        within this set, partitioned by substance identifier.
+        return tuple(self._properties)
 
-        See Also
-        --------
-        Substance.identifier()
-        """
-        return self._properties
+    @property
+    def property_types(self):
+        """set of str: The types of property within this data set."""
+        return set([x.__class__.__name__ for x in self._properties])
+
+    @property
+    def substances(self):
+        """set of Substance: The substances for which the properties in this data set
+        were collected for."""
+        return set([x.substance for x in self._properties])
 
     @property
     def sources(self):
-        """list of Source: The list of sources from which the properties were gathered"""
-        return self._sources
-
-    @property
-    def number_of_properties(self):
-        """int: The number of properties in the data set."""
-        return sum([len(properties) for properties in self._properties.values()])
+        """set of Source: The sources from which the properties in this data set were
+        gathered."""
+        return set([x.source for x in self._properties])
 
     def merge(self, data_set):
         """Merge another data set into the current one.
@@ -203,33 +204,80 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         if data_set is None:
             return
 
-        # TODO: Do we need to check whether merging the same data set here?
-        for substance_hash in data_set.properties:
-
-            if substance_hash not in self._properties:
-                self._properties[substance_hash] = []
-
-            self._properties[substance_hash].extend(data_set.properties[substance_hash])
-
-        self._sources.extend(data_set.sources)
+        self.add_properties(*data_set)
 
     def add_properties(self, *physical_properties):
         """Adds a physical property to the data set.
 
         Parameters
         ----------
-        physical_properties: tuple of PhysicalProperty
+        physical_properties: *PhysicalProperty
             The physical property to add.
         """
 
+        all_ids = set(x.id for x in self)
+
+        # TODO: Do we need to check for adding the same property twice?
         for physical_property in physical_properties:
 
-            if physical_property.substance.identifier not in self._properties:
-                self._properties[physical_property.substance.identifier] = []
+            physical_property.validate()
 
-            self._properties[physical_property.substance.identifier].append(
-                physical_property
-            )
+            if physical_property.id in all_ids:
+
+                raise KeyError(
+                    f"A property with the unique id {physical_property.id} already "
+                    f"exists."
+                )
+
+            all_ids.add(physical_property.id)
+
+        self._properties.extend(physical_properties)
+
+    def properties_by_substance(self, substance):
+        """A generator which may be used to loop over all of the properties
+        which were measured for a particular substance.
+
+        Parameters
+        ----------
+        substance: Substance
+            The substance of interest.
+
+        Returns
+        -------
+        generator of PhysicalProperty
+        """
+
+        for physical_property in self._properties:
+
+            if physical_property.substance != substance:
+                continue
+
+            yield physical_property
+
+    def properties_by_type(self, property_type):
+        """A generator which may be used to loop over all of properties
+        of a particular type, e.g. all "Density" properties.
+
+        Parameters
+        ----------
+        property_type: str or type of PhysicalProperty
+            The type of property of interest. This may either be the string
+            class name of the property or the class type.
+
+        Returns
+        -------
+        generator of PhysicalProperty
+        """
+
+        if not isinstance(property_type, str):
+            property_type = property_type.__name__
+
+        for physical_property in self._properties:
+
+            if physical_property.__class__.__name__ != property_type:
+                continue
+
+            yield physical_property
 
     def filter_by_function(self, filter_function):
         """Filter the data set using a given filter function.
@@ -239,33 +287,14 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         filter_function : lambda
             The filter function.
         """
+        self._properties = list(filter(filter_function, self._properties))
 
-        filtered_properties = {}
-
-        # This works for now - if we wish to be able to undo a filter then
-        # a 'filtered' list needs to be maintained separately to the main list.
-        for substance_id in self._properties:
-
-            substance_properties = list(
-                filter(filter_function, self._properties[substance_id])
-            )
-
-            if len(substance_properties) <= 0:
-                continue
-
-            filtered_properties[substance_id] = substance_properties
-
-        self._properties = {}
-
-        for substance_id in filtered_properties:
-            self._properties[substance_id] = filtered_properties[substance_id]
-
-    def filter_by_property_types(self, *property_type):
+    def filter_by_property_types(self, *property_types):
         """Filter the data set based on the type of property (e.g Density).
 
         Parameters
         ----------
-        property_type : PropertyType or str
+        property_types : PropertyType or str
             The type of property which should be retained.
 
         Examples
@@ -284,17 +313,13 @@ class PhysicalPropertyDataSet(TypedBaseModel):
 
         >>> data_set.filter_by_property_types('Density', 'DielectricConstant')
         """
-        property_types = []
 
-        for type_to_retain in property_type:
-
-            if isinstance(type_to_retain, str):
-                property_types.append(type_to_retain)
-            else:
-                property_types.append(type_to_retain.__name__)
+        property_types = [
+            x if isinstance(x, str) else x.__name__ for x in property_types
+        ]
 
         def filter_function(x):
-            return type(x).__name__ in property_types
+            return x.__class__.__name__ in property_types
 
         self.filter_by_function(filter_function)
 
@@ -384,7 +409,8 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         self.filter_by_function(filter_function)
 
     def filter_by_components(self, number_of_components):
-        """Filter the data set based on a minimum and maximum temperature.
+        """Filter the data set based on the number of components present
+        in the substance the data points were collected for.
 
         Parameters
         ----------
@@ -502,42 +528,24 @@ class PhysicalPropertyDataSet(TypedBaseModel):
         pandas.DataFrame
             The create data frame.
         """
+
+        if len(self) == 0:
+            return pandas.DataFrame()
+
         # Determine the maximum number of components for any
         # given measurements.
-        maximum_number_of_components = 0
-        all_property_types = set()
-
-        for substance_id in self._properties:
-
-            if len(self._properties[substance_id]) == 0:
-                continue
-
-            substance = self._properties[substance_id][0].substance
-            maximum_number_of_components = max(
-                maximum_number_of_components, substance.number_of_components
-            )
-
-            for physical_property in self._properties[substance_id]:
-                all_property_types.add(type(physical_property))
-
-        # Make sure the maximum number of components is not zero.
-        if maximum_number_of_components <= 0 < len(self._properties):
-
-            raise ValueError(
-                "The data set did not contain any substances with "
-                "one or more components."
-            )
+        maximum_number_of_components = max(
+            x.number_of_components for x in self.substances
+        )
 
         data_rows = []
 
         # Extract the data from the data set.
-        for substance_id in self._properties:
+        for substance in self.substances:
 
             data_points_by_state = defaultdict(dict)
 
-            for physical_property in self._properties[substance_id]:
-
-                all_property_types.add(type(physical_property))
+            for physical_property in self.properties_by_substance(substance):
 
                 # Extract the measured state.
                 temperature = physical_property.thermodynamic_state.temperature.to(
@@ -635,26 +643,40 @@ class PhysicalPropertyDataSet(TypedBaseModel):
             data_columns.append(f"Component {index + 1}")
             data_columns.append(f"Mole Fraction {index + 1}")
 
-        for property_type in all_property_types:
-            data_columns.append(f"{property_type.__name__} Value")
-            data_columns.append(f"{property_type.__name__} Uncertainty")
+        for property_type in self.property_types:
+            data_columns.append(f"{property_type} Value")
+            data_columns.append(f"{property_type} Uncertainty")
 
         data_frame = pandas.DataFrame(data_rows, columns=data_columns)
         return data_frame
 
     def __len__(self):
-        return self.number_of_properties
+        return len(self._properties)
+
+    def __iter__(self):
+        return iter(self._properties)
 
     def __getstate__(self):
-
-        return {"properties": self._properties, "sources": self._sources}
+        return {"properties": self._properties}
 
     def __setstate__(self, state):
 
         self._properties = state["properties"]
-        self._sources = state["sources"]
 
-        for key in self._properties:
-            assert all(isinstance(x, PhysicalProperty) for x in self._properties[key])
+        assert all(isinstance(x, PhysicalProperty) for x in self)
 
-        assert all(isinstance(x, Source) for x in self._sources)
+        for physical_property in self:
+            physical_property.validate()
+
+        # Ensure each property has a unique id.
+        all_ids = set(x.id for x in self)
+        assert len(all_ids) == len(self)
+
+    def __str__(self):
+        return (
+            f"n_properties={len(self)} n_substances={len(self.substances)} "
+            f"n_sources={len(self.sources)}"
+        )
+
+    def __repr__(self):
+        return f"<PhysicalPropertyDataSet {str(self)}>"

--- a/propertyestimator/datasets/thermoml/thermoml.py
+++ b/propertyestimator/datasets/thermoml/thermoml.py
@@ -1541,7 +1541,7 @@ class _PureOrMixtureData:
                 variable_value = float(
                     variable_node.find("ThermoML:nVarValue", namespace).text
                 )
-                value_as_quantity = pint.Quantity(
+                value_as_quantity = unit.Quantity(
                     variable_value, variable_definition.default_unit
                 )
 
@@ -2071,7 +2071,7 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
 
             data_set = cls._from_url(doi_url, MeasurementSource(doi=doi))
 
-            if data_set is None or len(data_set.properties) == 0:
+            if data_set is None or len(data_set) == 0:
                 continue
 
             if return_value is None:
@@ -2102,7 +2102,7 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
 
             data_set = cls._from_url(url)
 
-            if data_set is None or len(data_set.properties) == 0:
+            if data_set is None or len(data_set) == 0:
                 continue
 
             if return_value is None:
@@ -2166,7 +2166,7 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
 
             counter += 1
 
-            if data_set is None or len(data_set.properties) == 0:
+            if data_set is None or len(data_set) == 0:
                 continue
 
             if return_value is None:
@@ -2263,11 +2263,6 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
 
             for measured_property in properties:
 
-                substance_id = measured_property.substance.identifier
-
-                if substance_id not in return_value._properties:
-                    return_value._properties[substance_id] = []
-
                 registered_plugin = ThermoMLDataSet.registered_properties[
                     measured_property.type_string
                 ]
@@ -2276,8 +2271,6 @@ class ThermoMLDataSet(PhysicalPropertyDataSet):
                     measured_property
                 )
                 mapped_property.source = source
-                return_value._properties[substance_id].append(mapped_property)
-
-        return_value._sources.append(source)
+                return_value.add_properties(mapped_property)
 
         return return_value

--- a/propertyestimator/server/server.py
+++ b/propertyestimator/server/server.py
@@ -272,7 +272,7 @@ class EvaluatorServer:
 
         # Batch properties to be estimated for the same substance
         # into one chunk
-        for substance_identifier in submission.dataset.properties:
+        for substance in submission.dataset.substances:
 
             batch = _Batch()
             batch.force_field_id = force_field_id
@@ -285,8 +285,8 @@ class EvaluatorServer:
 
                 batch.id = str(uuid.uuid4()).replace("-", "")
 
-            batch.queued_properties = submission.dataset.properties[
-                substance_identifier
+            batch.queued_properties = [
+                x for x in submission.dataset.properties_by_substance(substance)
             ]
             batch.options = RequestOptions.parse_json(submission.options.json())
 

--- a/propertyestimator/tests/test_datasets/test_datasets.py
+++ b/propertyestimator/tests/test_datasets/test_datasets.py
@@ -133,6 +133,34 @@ def test_to_pandas():
     assert len(data_set_pandas) == 6
 
 
+def test_sources_substances():
+
+    physical_property = create_dummy_property(Density)
+
+    data_set = PhysicalPropertyDataSet()
+    data_set.add_properties(physical_property)
+
+    assert next(iter(data_set.sources)) == physical_property.source
+    assert next(iter(data_set.substances)) == physical_property.substance
+
+
+def test_properties_by_type():
+
+    density = create_dummy_property(Density)
+    dielectric = create_dummy_property(DielectricConstant)
+
+    data_set = PhysicalPropertyDataSet()
+    data_set.add_properties(density, dielectric)
+
+    densities = [x for x in data_set.properties_by_type("Density")]
+    assert len(densities) == 1
+    assert densities[0] == density
+
+    dielectrics = [x for x in data_set.properties_by_type("DielectricConstant")]
+    assert len(dielectrics) == 1
+    assert dielectrics[0] == dielectric
+
+
 def test_filter_by_property_types():
     """A test to ensure that data sets may be filtered by property type."""
 

--- a/propertyestimator/tests/test_datasets/test_datasets.py
+++ b/propertyestimator/tests/test_datasets/test_datasets.py
@@ -57,7 +57,7 @@ def test_serialization():
     data_set_json = data_set.json()
 
     parsed_data_set = PhysicalPropertyDataSet.parse_json(data_set_json)
-    assert data_set.number_of_properties == parsed_data_set.number_of_properties
+    assert len(data_set) == len(parsed_data_set)
 
     parsed_data_set_json = parsed_data_set.json()
     assert parsed_data_set_json == data_set_json
@@ -139,12 +139,12 @@ def test_filter_by_property_types():
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_property_types("Density")
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_property_types("Density", "DielectricConstant")
 
-    assert dummy_data_set.number_of_properties == 2
+    assert len(dummy_data_set) == 2
 
 
 def test_filter_by_phases():
@@ -153,14 +153,14 @@ def test_filter_by_phases():
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_phases(phases=PropertyPhase.Liquid)
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_phases(
         phases=PropertyPhase(PropertyPhase.Liquid | PropertyPhase.Solid)
     )
 
-    assert dummy_data_set.number_of_properties == 2
+    assert len(dummy_data_set) == 2
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_phases(
@@ -169,7 +169,7 @@ def test_filter_by_phases():
         )
     )
 
-    assert dummy_data_set.number_of_properties == 3
+    assert len(dummy_data_set) == 3
 
 
 def test_filter_by_temperature():
@@ -180,21 +180,21 @@ def test_filter_by_temperature():
         min_temperature=287 * unit.kelvin, max_temperature=289 * unit.kelvin
     )
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_temperature(
         min_temperature=287 * unit.kelvin, max_temperature=299 * unit.kelvin
     )
 
-    assert dummy_data_set.number_of_properties == 2
+    assert len(dummy_data_set) == 2
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_temperature(
         min_temperature=287 * unit.kelvin, max_temperature=309 * unit.kelvin
     )
 
-    assert dummy_data_set.number_of_properties == 3
+    assert len(dummy_data_set) == 3
 
 
 def test_filter_by_pressure():
@@ -205,21 +205,21 @@ def test_filter_by_pressure():
         min_pressure=0.4 * unit.atmosphere, max_pressure=0.6 * unit.atmosphere
     )
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_pressure(
         min_pressure=0.4 * unit.atmosphere, max_pressure=1.1 * unit.atmosphere
     )
 
-    assert dummy_data_set.number_of_properties == 2
+    assert len(dummy_data_set) == 2
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_pressure(
         min_pressure=0.4 * unit.atmosphere, max_pressure=1.6 * unit.atmosphere
     )
 
-    assert dummy_data_set.number_of_properties == 3
+    assert len(dummy_data_set) == 3
 
 
 def test_filter_by_components():
@@ -228,17 +228,17 @@ def test_filter_by_components():
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_components(number_of_components=1)
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_components(number_of_components=2)
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_components(number_of_components=3)
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
 
 def test_filter_by_elements():
@@ -248,17 +248,17 @@ def test_filter_by_elements():
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_elements("H", "C")
 
-    assert dummy_data_set.number_of_properties == 1
+    assert len(dummy_data_set) == 1
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_elements("H", "C", "N")
 
-    assert dummy_data_set.number_of_properties == 2
+    assert len(dummy_data_set) == 2
 
     dummy_data_set = create_filterable_data_set()
     dummy_data_set.filter_by_elements("H", "C", "N", "O")
 
-    assert dummy_data_set.number_of_properties == 3
+    assert len(dummy_data_set) == 3
 
 
 def test_filter_by_smiles():
@@ -278,11 +278,10 @@ def test_filter_by_smiles():
     property_b.substance = ethanol_substance
 
     data_set = PhysicalPropertyDataSet()
-    data_set.properties[methanol_substance.identifier] = [property_a]
-    data_set.properties[ethanol_substance.identifier] = [property_b]
+    data_set.add_properties(property_a, property_b)
 
     data_set.filter_by_smiles("CO")
 
-    assert data_set.number_of_properties == 1
-    assert methanol_substance.identifier in data_set.properties
-    assert ethanol_substance.identifier not in data_set.properties
+    assert len(data_set) == 1
+    assert methanol_substance in data_set.substances
+    assert ethanol_substance not in data_set.substances

--- a/propertyestimator/tests/test_datasets/test_thermoml.py
+++ b/propertyestimator/tests/test_datasets/test_thermoml.py
@@ -71,7 +71,7 @@ def test_thermoml_from_url():
     )
     assert data_set is not None
 
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     data_set = ThermoMLDataSet.from_url(
         "https://trc.nist.gov/ThermoML/10.1021/acs.jced.6b00916.xmld"
@@ -83,21 +83,9 @@ def test_thermoml_from_doi():
     """A test to ensure that ThermoML archive files can be loaded from a doi."""
 
     data_set = ThermoMLDataSet.from_doi("10.1016/j.jct.2016.10.001")
+
     assert data_set is not None
-
-    assert len(data_set.properties) > 0
-
-    for mixture_tag in data_set.properties:
-
-        for physical_property in data_set.properties[mixture_tag]:
-
-            physical_property_json = physical_property.json()
-            print(physical_property_json)
-
-            physical_property_recreated = PhysicalProperty.parse_json(
-                physical_property_json
-            )
-            print(physical_property_recreated)
+    assert len(data_set) > 0
 
     data_set = ThermoMLDataSet.from_doi("10.1016/j.jct.2016.12.009x")
     assert data_set is None
@@ -113,7 +101,7 @@ def test_thermoml_from_files():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) == 3
+    assert len(data_set) == 3
 
     data_set = ThermoMLDataSet.from_file("dummy_filename")
     assert data_set is None
@@ -127,7 +115,7 @@ def test_thermoml_mass_constraints():
     data_set = ThermoMLDataSet.from_file(get_data_filename("test/properties/mass.xml"))
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Mass fraction + Solvent: Mass fraction
     data_set = ThermoMLDataSet.from_file(
@@ -135,7 +123,7 @@ def test_thermoml_mass_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Mass fraction + Solvent: Mole fraction
     data_set = ThermoMLDataSet.from_file(
@@ -143,7 +131,7 @@ def test_thermoml_mass_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
 
 def test_thermoml_molality_constraints():
@@ -156,7 +144,7 @@ def test_thermoml_molality_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Molality + Solvent: Mass fraction
     data_set = ThermoMLDataSet.from_file(
@@ -164,7 +152,7 @@ def test_thermoml_molality_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Molality + Solvent: Mole fraction
     data_set = ThermoMLDataSet.from_file(
@@ -172,7 +160,7 @@ def test_thermoml_molality_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Molality + Solvent: Molality
     data_set = ThermoMLDataSet.from_file(
@@ -180,7 +168,7 @@ def test_thermoml_molality_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
 
 def test_thermoml_mole_constraints():
@@ -191,7 +179,7 @@ def test_thermoml_mole_constraints():
     data_set = ThermoMLDataSet.from_file(get_data_filename("test/properties/mole.xml"))
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Mole fraction + Solvent: Mass fraction
     data_set = ThermoMLDataSet.from_file(
@@ -199,7 +187,7 @@ def test_thermoml_mole_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Mole fraction + Solvent: Mole fraction
     data_set = ThermoMLDataSet.from_file(
@@ -207,7 +195,7 @@ def test_thermoml_mole_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0
 
     # Mole fraction + Solvent: Molality
     data_set = ThermoMLDataSet.from_file(
@@ -215,4 +203,4 @@ def test_thermoml_mole_constraints():
     )
 
     assert data_set is not None
-    assert len(data_set.properties) > 0
+    assert len(data_set) > 0

--- a/propertyestimator/tests/test_server.py
+++ b/propertyestimator/tests/test_server.py
@@ -86,7 +86,7 @@ def test_launch_batch():
         "Density": {"QuickCalculationLayer": CalculationLayerSchema()}
     }
     batch.parameter_gradient_keys = []
-    batch.queued_properties = next(iter(data_set.properties.values()))
+    batch.queued_properties = [*data_set]
     batch.validate()
 
     with tempfile.TemporaryDirectory() as directory:

--- a/propertyestimator/tests/test_utils/test_serialization.py
+++ b/propertyestimator/tests/test_utils/test_serialization.py
@@ -5,7 +5,6 @@ import json
 from enum import Enum, IntEnum
 
 import numpy as np
-import pint
 import pytest
 
 from propertyestimator import unit
@@ -215,7 +214,7 @@ def test_dimensionless_quantity_serialization():
 
     assert test_value == deserialized_value
 
-    test_value = pint.Quantity(1.0)
+    test_value = 1.0 * unit.dimensionless
 
     serialized_value = serialize_quantity(test_value)
     deserialized_value = deserialize_quantity(serialized_value)

--- a/propertyestimator/tests/utils.py
+++ b/propertyestimator/tests/utils.py
@@ -207,9 +207,7 @@ def create_filterable_data_set():
     )
 
     data_set = PhysicalPropertyDataSet()
-    data_set.properties[carbon_substance.identifier] = [density_property]
-    data_set.properties[nitrogen_substance.identifier] = [dielectric_property]
-    data_set.properties[oxygen_substance.identifier] = [enthalpy_property]
+    data_set.add_properties(density_property, dielectric_property, enthalpy_property)
 
     return data_set
 


### PR DESCRIPTION
## Description

This PR aims to make the `PhysicalPropertyDataSet` object more pythonic and user friendly. In future the entire object will likely need to be replaced by something robust, likely built on top of pandas, but for now these changes should be enough.

## Todos

This PR will:

- [X] Implement `__len__` and `__iter__` functions.
- [X] `properties` will now return a tuple of `PhysicalProperty` rather than a `dict`.
- [X] Add `properties_by_substance` and `properties_by_type` iterators.
- [X] Add `substances` and `property_types` attributes.
- [X] Change `sources` to be generated on request rather than be a stored property.
- [X] Add further validation (especially to ensure uniqueness of property ids).

## Breaking Changes

- `PhysicalPropertyDataSet.properties` is now a tuple of all `PhysicalProperty` objects in the set.
- `PhysicalPropertyDataSet.number_of_properties` has been removed in favour of `len(data_set)`.

## Status
- [X] Ready to go