### PR TITLE
Set Default Pint String Format

### DIFF
--- a/propertyestimator/__init__.py
+++ b/propertyestimator/__init__.py
@@ -11,6 +11,7 @@ from ._version import get_versions
 from .plugins import register_default_plugins, register_external_plugins
 
 unit = pint.UnitRegistry()
+unit.default_format = "~"
 pint.set_application_registry(unit)
 
 with warnings.catch_warnings():

--- a/propertyestimator/utils/openmm.py
+++ b/propertyestimator/utils/openmm.py
@@ -267,7 +267,7 @@ def pint_unit_to_openmm(pint_unit):
 
     assert isinstance(pint_unit, pint.Unit)
 
-    pint_unit_string = str(pint_unit)
+    pint_unit_string = f"{pint_unit:!s}"
 
     # Handle a unit name change in pint 0.10.*
     pint_unit_string = pint_unit_string.replace("standard_atmosphere", "atmosphere")


### PR DESCRIPTION
## Description
This PR sets the default `pint` string format to print units as abbreviated unit names - i.e `kPa` as opposed to `kilopascal`.

## Status
- [x] Ready to go