### PR TITLE
Expand RDKit Support

### DIFF
--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -62,7 +62,7 @@ jobs:
           python devtools/scripts/create_conda_env.py -n=test -p=${{ matrix.python-version }} devtools/conda-envs/test_env.yaml
 
       - name: Install OpenEye toolkit.
-        if: openeye
+        if: matrix.openeye
         run: |
 
           . devtools/scripts/initialize_conda.sh

--- a/.github/workflows/continous_integration.yaml
+++ b/.github/workflows/continous_integration.yaml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         os: [macOS-latest, ubuntu-latest]
         python-version: [3.6, 3.7]
+        openeye: [true, false]
 
     steps:
       - uses: actions/checkout@v2
@@ -61,6 +62,7 @@ jobs:
           python devtools/scripts/create_conda_env.py -n=test -p=${{ matrix.python-version }} devtools/conda-envs/test_env.yaml
 
       - name: Install OpenEye toolkit.
+        if: openeye
         run: |
 
           . devtools/scripts/initialize_conda.sh

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -32,5 +32,6 @@ dependencies:
   - pyyaml
   - requests
   - requests-mock # For testing http requests.
+  - rdkit
   - cmiles
   - python-dateutil

--- a/propertyestimator/datasets/thermoml/thermoml.py
+++ b/propertyestimator/datasets/thermoml/thermoml.py
@@ -418,7 +418,7 @@ class _Compound:
         if thermoml_string is None:
             raise ValueError("The string cannot be `None`.")
 
-        molecule = load_molecule(thermoml_string)
+        molecule = load_molecule(thermoml_string, toolkit="rdkit")
         return mol_to_smiles(molecule, explicit_hydrogen=False, mapped=False)
 
     @staticmethod
@@ -444,7 +444,7 @@ class _Compound:
         try:
 
             molecule = Molecule.from_iupac(common_name, allow_undefined_stereo=True)
-            cmiles_molecule = load_molecule(molecule.to_smiles())
+            cmiles_molecule = load_molecule(molecule.to_smiles(), toolkit="rdkit")
             smiles = mol_to_smiles(
                 cmiles_molecule, explicit_hydrogen=False, mapped=False
             )

--- a/propertyestimator/protocols/forcefield.py
+++ b/propertyestimator/protocols/forcefield.py
@@ -384,7 +384,7 @@ class TemplateBuildSystem(BaseBuildSystem, abc.ABC):
 
         for index, (smiles, unique_molecule) in enumerate(unique_molecules.items()):
 
-            if smiles in ["O", "[H]O[H]"]:
+            if smiles in ["O", "[H]O[H]", "[H][O][H]"]:
 
                 component_system = self._build_tip3p_system(
                     cutoff, openmm_pdb_file.topology.getUnitCellDimensions(),

--- a/propertyestimator/substances/components.py
+++ b/propertyestimator/substances/components.py
@@ -82,7 +82,7 @@ class Component(AttributeClass):
         """
         from cmiles.utils import load_molecule, mol_to_smiles
 
-        molecule = load_molecule(smiles)
+        molecule = load_molecule(smiles, toolkit="rdkit")
 
         try:
             # Try to make the smiles isomeric.

--- a/propertyestimator/tests/test_protocols/test_coordinates.py
+++ b/propertyestimator/tests/test_protocols/test_coordinates.py
@@ -13,7 +13,7 @@ from propertyestimator.protocols.coordinates import (
     SolvateExistingStructure,
 )
 from propertyestimator.substances import Component, ExactAmount, MoleFraction, Substance
-from propertyestimator.utils import get_data_filename
+from propertyestimator.utils import get_data_filename, has_openeye
 
 
 def _build_input_output_substances():
@@ -105,6 +105,9 @@ def test_solvate_existing_structure_protocol():
 
 def test_build_docked_coordinates_protocol():
     """Tests docking a methanol molecule into alpha-Cyclodextrin."""
+
+    if not has_openeye():
+        pytest.skip("The `BuildDockedCoordinates` protocol requires OpenEye.")
 
     ligand_substance = Substance()
     ligand_substance.add_component(

--- a/propertyestimator/tests/test_substances.py
+++ b/propertyestimator/tests/test_substances.py
@@ -12,8 +12,8 @@ from propertyestimator.substances import Component, ExactAmount, MoleFraction, S
     [
         ("C1=CC=CC=C1", "c1ccccc1"),
         ("c1ccccc1", "c1ccccc1"),
-        ("[C@H](F)(Cl)Br", "[C@H](F)(Cl)Br"),
-        ("C(F)(Cl)Br", "C(F)(Cl)Br"),
+        ("[C@H](F)(Cl)Br", "F[C@@H](Cl)Br"),
+        ("C(F)(Cl)Br", "FC(Cl)Br"),
     ],
 )
 def test_component_standardization(smiles, expected):


### PR DESCRIPTION
## Description
This PR expands support for RDKit by:

- instructing `cmiles` to use `rdkit` for smiles standardisation
- skipping OE dependant tests.
- fixing tests against OE style smiles.

## Status
- [x] Ready to go