### PR TITLE
Make the Server Batch Object Public.

### DIFF
--- a/propertyestimator/layers/layers.py
+++ b/propertyestimator/layers/layers.py
@@ -137,7 +137,7 @@ class CalculationLayer(abc.ABC):
             The backend to the submit the calculations to.
         storage_backend: StorageBackend
             The backend used to store / retrieve data from previous calculations.
-        batch: _Batch
+        batch: Batch
             The request object which spawned the awaited results.
         callback: function
             The function to call when the backend returns the results (or an error).
@@ -168,7 +168,7 @@ class CalculationLayer(abc.ABC):
 
         Parameters
         ----------
-        batch: _Batch
+        batch: Batch
             The request which generated the cached data.
         returned_output: CalculationLayerResult
             The layer result which contains the cached data.
@@ -211,7 +211,7 @@ class CalculationLayer(abc.ABC):
         ----------
         results_future: distributed.Future
             The future object which will hold the results.
-        batch: _Batch
+        batch: Batch
             The batch which spawned the awaited results.
         layer_name: str
             The name of the layer processing the results.
@@ -361,7 +361,7 @@ class CalculationLayer(abc.ABC):
         layer_directory: str
             The directory in which to store all temporary calculation data from this
             layer.
-        batch: _Batch
+        batch: Batch
             The batch of properties to estimate with the layer.
 
         Returns
@@ -393,7 +393,7 @@ class CalculationLayer(abc.ABC):
         layer_directory: str
             The directory in which to store all temporary calculation data from this
             layer.
-        batch: _Batch
+        batch: Batch
             The batch of properties to estimate with the layer.
         callback: function
             The function to call when the backend returns the results (or an error).

--- a/propertyestimator/server/__init__.py
+++ b/propertyestimator/server/__init__.py
@@ -1,3 +1,3 @@
-from .server import EvaluatorServer
+from .server import Batch, EvaluatorServer
 
-__all__ = [EvaluatorServer]
+__all__ = [Batch, EvaluatorServer]

--- a/propertyestimator/server/server.py
+++ b/propertyestimator/server/server.py
@@ -30,17 +30,15 @@ from propertyestimator.utils.tcp import (
 logger = logging.getLogger(__name__)
 
 
-class _Batch(AttributeClass):
-    """Represents a batch of physical properties which are
-    being estimated by the server for a given set of force
-    field parameters.
+class Batch(AttributeClass):
+    """Represents a batch of physical properties which are being estimated by
+    the server for a given set of force field parameters.
 
-    The expectation is that this object will be passed between
-    calculation layers, whereby each layer will attempt to
-    estimate each of the `queued_properties`. Those properties
-    which can be estimated will be moved to the `estimated_properties`
-    set, while those that couldn't will remain in the `queued_properties`
-    set ready for the next layer.
+    The expectation is that this object will be passed between calculation layers,
+    whereby each layer will attempt to estimate each of the `queued_properties`.
+    Those properties which can be estimated will be moved to the `estimated_properties`
+    set, while those that couldn't will remain in the `queued_properties` set ready
+    for the next layer.
     """
 
     id = Attribute(
@@ -87,7 +85,7 @@ class _Batch(AttributeClass):
     )
 
     def validate(self, attribute_type=None):
-        super(_Batch, self).validate(attribute_type)
+        super(Batch, self).validate(attribute_type)
 
         assert all(isinstance(x, PhysicalProperty) for x in self.queued_properties)
         assert all(isinstance(x, PhysicalProperty) for x in self.estimated_properties)
@@ -261,7 +259,7 @@ class EvaluatorServer:
 
         Returns
         -------
-        list of _Batch
+        list of Batch
             A list of the batches to launch.
         """
 
@@ -274,7 +272,7 @@ class EvaluatorServer:
         # into one chunk
         for substance in submission.dataset.substances:
 
-            batch = _Batch()
+            batch = Batch()
             batch.force_field_id = force_field_id
 
             # Make sure we don't somehow generate the same uuid
@@ -309,7 +307,7 @@ class EvaluatorServer:
 
         Parameters
         ----------
-        batch : _Batch
+        batch : Batch
             The batch to launch.
         """
 

--- a/propertyestimator/tests/test_layers/test_layers.py
+++ b/propertyestimator/tests/test_layers/test_layers.py
@@ -129,7 +129,7 @@ def test_base_layer():
 
     dummy_options = RequestOptions()
 
-    batch = server._Batch()
+    batch = server.Batch()
     batch.queued_properties = properties_to_estimate
     batch.options = dummy_options
     batch.force_field_id = ""

--- a/propertyestimator/tests/test_layers/test_workflow_layer.py
+++ b/propertyestimator/tests/test_layers/test_workflow_layer.py
@@ -42,7 +42,7 @@ def test_workflow_layer():
     options = RequestOptions()
     options.add_schema("SimulationLayer", "Density", layer_schema)
 
-    batch = server._Batch()
+    batch = server.Batch()
     batch.queued_properties = properties_to_estimate
     batch.options = options
 

--- a/propertyestimator/tests/test_server.py
+++ b/propertyestimator/tests/test_server.py
@@ -14,7 +14,7 @@ from propertyestimator.layers import (
 )
 from propertyestimator.layers.layers import CalculationLayerResult
 from propertyestimator.properties import Density
-from propertyestimator.server.server import EvaluatorServer, Batch
+from propertyestimator.server.server import Batch, EvaluatorServer
 from propertyestimator.tests.utils import create_dummy_property
 from propertyestimator.utils.utils import temporarily_change_directory
 

--- a/propertyestimator/tests/test_server.py
+++ b/propertyestimator/tests/test_server.py
@@ -14,7 +14,7 @@ from propertyestimator.layers import (
 )
 from propertyestimator.layers.layers import CalculationLayerResult
 from propertyestimator.properties import Density
-from propertyestimator.server.server import EvaluatorServer, _Batch
+from propertyestimator.server.server import EvaluatorServer, Batch
 from propertyestimator.tests.utils import create_dummy_property
 from propertyestimator.utils.utils import temporarily_change_directory
 
@@ -78,7 +78,7 @@ def test_launch_batch():
         create_dummy_property(Density), create_dummy_property(Density)
     )
 
-    batch = _Batch()
+    batch = Batch()
     batch.force_field_id = ""
     batch.options = RequestOptions()
     batch.options.calculation_layers = ["QuickCalculationLayer"]


### PR DESCRIPTION
## Description
This PR makes the `server._Batch` public. Given that users implementing their own calculation layers will make use of this object, it makes sense for it to be publicly exposed as `server.Batch`.

## Status
- [X] Ready to go